### PR TITLE
Add WarmRestart callback

### DIFF
--- a/keras_contrib/callbacks/__init__.py
+++ b/keras_contrib/callbacks/__init__.py
@@ -1,2 +1,3 @@
 from .snapshot import SnapshotCallbackBuilder, SnapshotModelCheckpoint
 from .dead_relu_detector import DeadReluDetector
+from .warm_restart import WarmRestart

--- a/keras_contrib/callbacks/__init__.py
+++ b/keras_contrib/callbacks/__init__.py
@@ -1,3 +1,3 @@
 from .snapshot import SnapshotCallbackBuilder, SnapshotModelCheckpoint
 from .dead_relu_detector import DeadReluDetector
-from .warm_restart import WarmRestart
+from .warm_restart import LearningRateWarmRestarter

--- a/keras_contrib/callbacks/warm_restart.py
+++ b/keras_contrib/callbacks/warm_restart.py
@@ -3,7 +3,7 @@ from keras.callbacks import Callback
 import keras.backend as K
 
 
-class WarmRestart(Callback):
+class LearningRateWarmRestarter(Callback):
     """Warm Restart Learning rate update rule.
     # Arguments
         min_lr: lower bound on the learning rate.
@@ -16,7 +16,7 @@ class WarmRestart(Callback):
     """
 
     def __init__(self, min_lr=0., max_lr=0.1, num_restart_epochs=5, factor=1):
-        super(WarmRestart, self).__init__()
+        super(LearningRateWarmRestarter, self).__init__()
         self.min_lr = min_lr
         self.max_lr = max_lr
         self.num_restart_epochs = num_restart_epochs

--- a/keras_contrib/callbacks/warm_restart.py
+++ b/keras_contrib/callbacks/warm_restart.py
@@ -5,17 +5,27 @@ import keras.backend as K
 
 class LearningRateWarmRestarter(Callback):
     """Warm Restart Learning rate update rule.
+    Warm restart technique is a way to improve the rate of convergence for stochastic gradient descent.
+
     # Arguments
         min_lr: lower bound on the learning rate.
         max_lr: upper bound on the learning rate.
         num_restart_epochs:  restart learning rate from `max_lr` at every `num_restart_epochs`.
-        factor: factor by which the number of restart epochs will be increased. new_num_restart_epochs = num_restart_epochs*factor.
+        factor: a factor by which the number of restart epochs will be increased. `new_num_restart_epochs = num_restart_epochs * factor`.
 
     # Reference
         [SGDR: Stochastic Gradient Descent with Warm Restarts](https://arxiv.org/pdf/1608.03983.pdf)
+
+    # Example
+
+    ```python
+    warm_restart_lr = LearningRateWarmRestarter(min_lr=0., max_lr=0.1,
+                                                num_restart_epochs=5, factor=2)
+    model.fit(x_train, y_train, callbacks=[warm_restart_lr])
+    ```
     """
 
-    def __init__(self, min_lr=0., max_lr=0.1, num_restart_epochs=5, factor=1):
+    def __init__(self, min_lr=0., max_lr=0.1, num_restart_epochs=5, factor=2):
         super(LearningRateWarmRestarter, self).__init__()
         self.min_lr = min_lr
         self.max_lr = max_lr
@@ -24,7 +34,7 @@ class LearningRateWarmRestarter(Callback):
         self.next_restart_epochs = 0
 
         if factor < 1:
-            raise ValueError('"factor" must be larger than 0')
+            raise ValueError('"factor" must be larger than 1 or equal 1')
 
     def on_epoch_begin(self, epoch, logs=None):
         if not hasattr(self.model.optimizer, 'lr'):

--- a/keras_contrib/callbacks/warm_restart.py
+++ b/keras_contrib/callbacks/warm_restart.py
@@ -1,0 +1,38 @@
+import numpy as np
+from keras.callbacks import Callback
+
+class WarmRestart(Callback):
+    """Warm Restart Learning rate update rule.
+    # Arguments
+        eta_min: float. min value of learning rate
+        eta_max: float. max value of learning rate
+        T_0: initial the number of epochs to restart
+        T_mult: increase scale factor of T_0.
+
+    # Reference
+        [SGDR: STOCHASTIC GRADIENT DESCENT WITH WARM RESTARTS](https://arxiv.org/pdf/1608.03983.pdf)
+    """
+
+    def __init__(self, eta_min=0., eta_max=0.1, T_0=5, T_mult=1):
+        super(WarmRestart, self).__init__()
+        self.T_i = T_0
+        self.T_mult = T_mult
+        self.eta_min = eta_min
+        self.eta_max = eta_max
+        self.T_cur = 0
+        self.cum_previous_Ti = 0
+
+    def on_epoch_begin(self, epoch, logs=None):
+        if not hasattr(self.model.optimizer, 'lr'):
+            raise ValueError('Optimizer must have a "lr" attribute.')
+
+        T_cur = epoch - self.cum_previous_Ti
+        print(epoch, T_cur, self.cum_previous_Ti)
+
+        lr = self.eta_min + 0.5 * (self.eta_max - self.eta_min) * (1. + np.cos(T_cur / self.T_i * np.pi))
+        
+        if T_cur == self.T_i:
+            self.cum_previous_Ti += self.T_i
+            self.T_i *= self.T_mult
+
+        K.set_value(self.model.optimizer.lr, lr)

--- a/tests/keras_contrib/callbacks/warm_restart_test.py
+++ b/tests/keras_contrib/callbacks/warm_restart_test.py
@@ -1,0 +1,42 @@
+from keras.models import Sequential
+from keras.layers.core import Dense
+from keras.utils.test_utils import get_test_data
+from keras import backend as K
+from keras.utils import np_utils
+from keras_contrib import callbacks
+
+import numpy as np
+import pytest
+
+input_dim = 2
+num_hidden = 4
+num_classes = 2
+batch_size = 5
+train_samples = 20
+test_samples = 20
+
+
+def LearningRateWarmRestarter():
+    np.random.seed(1337)
+    (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
+                                                         num_test=test_samples,
+                                                         input_shape=(input_dim,),
+                                                         classification=True,
+                                                         num_classes=num_classes)
+    y_test = np_utils.to_categorical(y_test)
+    y_train = np_utils.to_categorical(y_train)
+    model = Sequential()
+    model.add(Dense(num_hidden, input_dim=input_dim))
+    model.add(Dense(num_classes, activation='softmax'))
+    model.compile(loss='categorical_crossentropy',
+                  optimizer='sgd',
+                  metrics=['accuracy'])
+
+    max_lr = 0.1
+    cbks = [callbacks.LearningRateWarmRestarter(min_lr=0., max_lr=max_lr, num_restart_epochs=5, factor=2)]
+    model.fit(X_train, y_train, batch_size=batch_size,
+              validation_data=(X_test, y_test), callbacks=cbks, epochs=6)
+    assert (float(K.get_value(model.optimizer.lr)) - max_lr) < K.epsilon()
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/keras_contrib/callbacks/warm_restart_test.py
+++ b/tests/keras_contrib/callbacks/warm_restart_test.py
@@ -16,7 +16,7 @@ train_samples = 20
 test_samples = 20
 
 
-def LearningRateWarmRestarter():
+def test_LearningRateWarmRestarter():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
                                                          num_test=test_samples,


### PR DESCRIPTION
Warm Restart is a technique to update learning rate. I think that it is useful to add this as the new callback function for Keras users.

## TODO

- [x] Add test based on `test_LearningRateScheduler` in [callback test code](https://github.com/keras-team/keras/blob/master/tests/keras/test_callbacks.py).
- [x] Show learning process plot that is similar to original paper.
- [x] Improve docstring

---

Reference: Ilya Loshchilov, Frank Hutter. SGDR:   Stochastic Gradient Descent with Warm Restarts. In ICLR, 2017. [paper](https://arxiv.org/pdf/1608.03983.pdf).