### PR TITLE
add logsumexp in tensorflow_backend.py

### DIFF
--- a/keras_contrib/backend/cntk_backend.py
+++ b/keras_contrib/backend/cntk_backend.py
@@ -1,4 +1,5 @@
 from keras.backend import cntk_backend as KCN
+from keras.backend.cntk_backend import logsumexp
 import cntk as C
 import numpy as np
 

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -188,4 +188,3 @@ def clip(x, min_value, max_value):
     max_value = _to_tensor(max_value, x.dtype.base_dtype)
     max_value = tf.maximum(min_value, max_value)
     return tf.clip_by_value(x, min_value, max_value)
-

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -187,3 +187,23 @@ def clip(x, min_value, max_value):
     max_value = _to_tensor(max_value, x.dtype.base_dtype)
     max_value = tf.maximum(min_value, max_value)
     return tf.clip_by_value(x, min_value, max_value)
+
+def logsumexp(x, axis=None, keepdims=False):
+    """Computes log(sum(exp(elements across dimensions of a tensor))).
+
+    This function is more numerically stable than log(sum(exp(x))).
+    It avoids overflows caused by taking the exp of large inputs and
+    underflows caused by taking the log of small inputs.
+
+    # Arguments
+        x: A tensor or variable.
+        axis: An integer, the axis to reduce over.
+        keepdims: A boolean, whether to keep the dimensions or not.
+            If `keepdims` is `False`, the rank of the tensor is reduced
+            by 1. If `keepdims` is `True`, the reduced dimension is
+            retained with length 1.
+
+    # Returns
+        The reduced tensor.
+    """
+    return tf.reduce_logsumexp(x, axis, keepdims)

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -10,7 +10,7 @@ from keras.backend import dtype
 from keras.backend.common import floatx
 from keras.backend.common import image_data_format
 from keras.backend.tensorflow_backend import _to_tensor
-from keras.backend import logsumexp
+from keras.backend.tensorflow_backend import logsumexp
 
 py_all = all
 

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -10,6 +10,7 @@ from keras.backend import dtype
 from keras.backend.common import floatx
 from keras.backend.common import image_data_format
 from keras.backend.tensorflow_backend import _to_tensor
+from keras.backend import logsumexp
 
 py_all = all
 
@@ -188,22 +189,3 @@ def clip(x, min_value, max_value):
     max_value = tf.maximum(min_value, max_value)
     return tf.clip_by_value(x, min_value, max_value)
 
-def logsumexp(x, axis=None, keepdims=False):
-    """Computes log(sum(exp(elements across dimensions of a tensor))).
-
-    This function is more numerically stable than log(sum(exp(x))).
-    It avoids overflows caused by taking the exp of large inputs and
-    underflows caused by taking the log of small inputs.
-
-    # Arguments
-        x: A tensor or variable.
-        axis: An integer, the axis to reduce over.
-        keepdims: A boolean, whether to keep the dimensions or not.
-            If `keepdims` is `False`, the rank of the tensor is reduced
-            by 1. If `keepdims` is `True`, the reduced dimension is
-            retained with length 1.
-
-    # Returns
-        The reduced tensor.
-    """
-    return tf.reduce_logsumexp(x, axis, keepdims)

--- a/keras_contrib/backend/theano_backend.py
+++ b/keras_contrib/backend/theano_backend.py
@@ -21,8 +21,6 @@ from keras.backend.theano_backend import _preprocess_conv2d_input
 from keras.backend.theano_backend import _postprocess_conv2d_output
 from keras.backend.theano_backend import logsumexp
 
-
-
 py_all = all
 
 

--- a/keras_contrib/backend/theano_backend.py
+++ b/keras_contrib/backend/theano_backend.py
@@ -19,6 +19,8 @@ from keras.backend.theano_backend import _preprocess_padding
 from keras.backend.theano_backend import _postprocess_conv3d_output
 from keras.backend.theano_backend import _preprocess_conv2d_input
 from keras.backend.theano_backend import _postprocess_conv2d_output
+from keras.backend.theano_backend import logsumexp
+
 
 
 py_all = all


### PR DESCRIPTION
In crf.py there is a calling for backend.logsumexp. When using tensorflow as backend, an error will occur as there is no such a function in keras_contrib.backend tensorflow.py.