### PR TITLE
densenet.py pooling defaults, transition_pooling, early_transition DenseNetFCN option

### DIFF
--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -710,7 +710,7 @@ def __transition_up_block(ip, nb_filters, type='deconv', weight_decay=1E-4, bloc
 
 def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_block=3, growth_rate=12, nb_filter=-1,
                        nb_layers_per_block=-1, bottleneck=False, reduction=0.0, dropout_rate=None, weight_decay=1e-4,
-                       subsample_initial_block=False, pooling=None, activation='softmax', transition_pooling='max'):
+                       subsample_initial_block=False, pooling=None, activation='softmax', transition_pooling='avg'):
     ''' Build the DenseNet model
 
     # Arguments
@@ -749,7 +749,7 @@ def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_bl
                 be applied.
         activation: Type of activation at the top layer. Can be one of 'softmax' or 'sigmoid'.
                 Note that if sigmoid is used, classes must be 1.
-        transition_pooling: 'max' for max pooling (default), 'avg' for average pooling,
+        transition_pooling: 'avg' for average pooling(default), 'max' for max pooling,
             None for no pooling.
 
     # Returns
@@ -876,7 +876,8 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
         early_transition: Start with an extra initial transition down and end with an extra
             transition up to reduce the network size.
         transition_pooling: 'max' for max pooling (default), 'avg' for average pooling,
-            None for no pooling.
+            None for no pooling. Please note that this default differs from the DenseNet
+            paper in accordance with the DenseNetFCN paper.
 
     # Returns
         a keras tensor

--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -757,11 +757,10 @@ def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_bl
                 be applied.
         activation: Type of activation at the top layer. Can be one of 'softmax' or 'sigmoid'.
                 Note that if sigmoid is used, classes must be 1.
-        transition_pooling: 'max' for max pooling (default), 'avg' for average pooling,
-            None for no pooling. Please note that this default differs from the DenseNet
-            paper in accordance with the DenseNetFCN paper.
-        initial_kernel_size: The first Conv2D kernel might vary in size based on the
-            application, this parameter makes it configurable.
+        transition_pooling: `avg` for avg pooling (default), `max` for max pooling,
+            None for no pooling during scale transition blocks. Please note that this
+            default differs from the DenseNetFCN paper in accordance with the DenseNet
+            paper.
 
     # Returns
         a keras tensor

--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -113,7 +113,8 @@ def DenseNet(input_shape=None,
              input_tensor=None,
              pooling=None,
              classes=10,
-             activation='softmax'):
+             activation='softmax',
+             transition_pooling='avg'):
     '''Instantiate the DenseNet architecture.
 
     The model and the weights are compatible with both
@@ -167,12 +168,18 @@ def DenseNet(input_shape=None,
                 2D tensor.
             - `max` means that global max pooling will
                 be applied.
+        initial_kernel_size: The first Conv2D kernel might vary in size based on the
+            application, this parameter makes it configurable.
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
         activation: Type of activation at the top layer. Can be one of
             'softmax' or 'sigmoid'. Note that if sigmoid is used,
              classes must be 1.
+        transition_pooling: `avg` for avg pooling (default), `max` for max pooling,
+            None for no pooling during scale transition blocks. Please note that this
+            default differs from the DenseNetFCN paper in accordance with the DenseNet
+            paper.
 
     # Returns
         A Keras model instance.
@@ -215,7 +222,7 @@ def DenseNet(input_shape=None,
     x = __create_dense_net(classes, img_input, include_top, depth, nb_dense_block,
                            growth_rate, nb_filter, nb_layers_per_block, bottleneck,
                            reduction, dropout_rate, weight_decay, subsample_initial_block,
-                           pooling, activation)
+                           pooling, activation, transition_pooling)
 
     # Ensure that the model takes into account
     # any potential predecessors of `input_tensor`.
@@ -298,7 +305,7 @@ def DenseNetFCN(input_shape, nb_dense_block=5, growth_rate=16, nb_layers_per_blo
                 reduction=0.0, dropout_rate=0.0, weight_decay=1E-4, init_conv_filters=48,
                 include_top=True, weights=None, input_tensor=None, classes=1, activation='softmax',
                 upsampling_conv=128, upsampling_type='deconv', early_transition=False,
-                pooling='max', initial_kernel_size=(3, 3)):
+                transition_pooling='max', initial_kernel_size=(3, 3)):
     '''Instantiate the DenseNet FCN architecture.
         Note that when using TensorFlow,
         for best performance you should set
@@ -618,7 +625,7 @@ def __dense_block(x, nb_layers, nb_filter, growth_rate, bottleneck=False, dropou
             return x, nb_filter
 
 
-def __transition_block(ip, nb_filter, compression=1.0, weight_decay=1e-4, block_prefix=None, pooling='max'):
+def __transition_block(ip, nb_filter, compression=1.0, weight_decay=1e-4, block_prefix=None, transition_pooling='max'):
     '''
     Adds a pointwise convolution layer (with batch normalization and relu),
     and an average pooling layer. The number of output convolution filters
@@ -657,9 +664,9 @@ def __transition_block(ip, nb_filter, compression=1.0, weight_decay=1e-4, block_
         x = Activation('relu')(x)
         x = Conv2D(int(nb_filter * compression), (1, 1), kernel_initializer='he_normal', padding='same',
                    use_bias=False, kernel_regularizer=l2(weight_decay), name=name_or_none(block_prefix, '_conv2D'))(x)
-        if pooling == 'avg':
+        if transition_pooling == 'avg':
             x = AveragePooling2D((2, 2), strides=(2, 2))(x)
-        if pooling == 'max':
+        elif transition_pooling == 'max':
             x = MaxPooling2D((2, 2), strides=(2, 2))(x)
 
         return x
@@ -750,8 +757,11 @@ def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_bl
                 be applied.
         activation: Type of activation at the top layer. Can be one of 'softmax' or 'sigmoid'.
                 Note that if sigmoid is used, classes must be 1.
-        transition_pooling: 'avg' for average pooling(default), 'max' for max pooling,
-            None for no pooling.
+        transition_pooling: 'max' for max pooling (default), 'avg' for average pooling,
+            None for no pooling. Please note that this default differs from the DenseNet
+            paper in accordance with the DenseNetFCN paper.
+        initial_kernel_size: The first Conv2D kernel might vary in size based on the
+            application, this parameter makes it configurable.
 
     # Returns
         a keras tensor
@@ -821,7 +831,7 @@ def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_bl
                                          block_prefix='dense_%i' % block_idx)
             # add transition_block
             x = __transition_block(x, nb_filter, compression=compression, weight_decay=weight_decay,
-                                   block_prefix='tr_%i' % block_idx, pooling=transition_pooling)
+                                   block_prefix='tr_%i' % block_idx, transition_pooling=transition_pooling)
             nb_filter = int(nb_filter * compression)
 
         # The last dense_block does not have a transition_block
@@ -835,13 +845,13 @@ def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_bl
         if include_top:
             if pooling == 'avg':
                 x = GlobalAveragePooling2D()(x)
-            if pooling == 'max':
+            elif pooling == 'max':
                 x = GlobalMaxPooling2D()(x)
             x = Dense(nb_classes, activation=activation)(x)
         else:
             if pooling == 'avg':
                 x = GlobalAveragePooling2D()(x)
-            if pooling == 'max':
+            elif pooling == 'max':
                 x = GlobalMaxPooling2D()(x)
 
         return x
@@ -879,6 +889,8 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
         transition_pooling: 'max' for max pooling (default), 'avg' for average pooling,
             None for no pooling. Please note that this default differs from the DenseNet
             paper in accordance with the DenseNetFCN paper.
+        initial_kernel_size: The first Conv2D kernel might vary in size based on the
+            application, this parameter makes it configurable.
 
     # Returns
         a keras tensor
@@ -935,7 +947,7 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
 
         if early_transition:
             x = __transition_block(x, nb_filter, compression=compression, weight_decay=weight_decay,
-                                   block_prefix='tr_early', pooling=transition_pooling)
+                                   block_prefix='tr_early', transition_pooling=transition_pooling)
 
         # Add dense blocks and transition down block
         for block_idx in range(nb_dense_block):
@@ -947,7 +959,7 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
 
             # add transition_block
             x = __transition_block(x, nb_filter, compression=compression, weight_decay=weight_decay,
-                                   block_prefix='tr_%i' % block_idx, pooling=transition_pooling)
+                                   block_prefix='tr_%i' % block_idx, transition_pooling=transition_pooling)
 
             nb_filter = int(nb_filter * compression)  # this is calculated inside transition_down_block
 

--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -168,8 +168,6 @@ def DenseNet(input_shape=None,
                 2D tensor.
             - `max` means that global max pooling will
                 be applied.
-        initial_kernel_size: The first Conv2D kernel might vary in size based on the
-            application, this parameter makes it configurable.
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -351,6 +349,8 @@ def DenseNetFCN(input_shape, nb_dense_block=5, growth_rate=16, nb_layers_per_blo
                 output shape of deconvolution layers automatically.
             early_transition: Start with an extra initial transition down and end with an extra
                 transition up to reduce the network size.
+            initial_kernel_size: The first Conv2D kernel might vary in size based on the
+                application, this parameter makes it configurable.
 
         # Returns
             A Keras model instance.

--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -202,7 +202,7 @@ def DenseNet(input_shape=None,
                                       default_size=32,
                                       min_size=8,
                                       data_format=K.image_data_format(),
-                                      include_top=include_top)
+                                      require_flatten=include_top)
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)

--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -298,7 +298,7 @@ def DenseNetFCN(input_shape, nb_dense_block=5, growth_rate=16, nb_layers_per_blo
                 reduction=0.0, dropout_rate=0.0, weight_decay=1E-4, init_conv_filters=48,
                 include_top=True, weights=None, input_tensor=None, classes=1, activation='softmax',
                 upsampling_conv=128, upsampling_type='deconv', early_transition=False,
-                pooling='max'):
+                pooling='max', initial_kernel_size=(3, 3)):
     '''Instantiate the DenseNet FCN architecture.
         Note that when using TensorFlow,
         for best performance you should set
@@ -403,10 +403,11 @@ def DenseNetFCN(input_shape, nb_dense_block=5, growth_rate=16, nb_layers_per_blo
         else:
             img_input = input_tensor
 
-    x = __create_fcn_dense_net(classes, img_input, include_top, nb_dense_block,
-                               growth_rate, reduction, dropout_rate, weight_decay,
+    x = __create_fcn_dense_net(classes, img_input, include_top, nb_dense_block, growth_rate,
+                               reduction, dropout_rate, weight_decay,
                                nb_layers_per_block, upsampling_conv, upsampling_type,
-                               init_conv_filters, input_shape, activation, early_transition)
+                               init_conv_filters, input_shape, activation,
+                               early_transition, transition_pooling, initial_kernel_size)
 
     # Ensure that the model takes into account
     # any potential predecessors of `input_tensor`.
@@ -848,9 +849,9 @@ def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_bl
 
 def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5, growth_rate=12,
                            reduction=0.0, dropout_rate=None, weight_decay=1e-4,
-                           nb_layers_per_block=4, nb_upsampling_conv=128, upsampling_type='upsampling',
-                           init_conv_filters=48, input_shape=None, activation='deconv',
-                           early_transition=False, transition_pooling='max'):
+                           nb_layers_per_block=4, nb_upsampling_conv=128, upsampling_type='deconv',
+                           init_conv_filters=48, input_shape=None, activation='softmax',
+                           early_transition=False, transition_pooling='max', initial_kernel_size=(3, 3)):
     ''' Build the DenseNet-FCN model
 
     # Arguments
@@ -923,7 +924,7 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
         compression = 1.0 - reduction
 
         # Initial convolution
-        x = Conv2D(init_conv_filters, (7, 7), kernel_initializer='he_normal', padding='same', name='initial_conv2D',
+        x = Conv2D(init_conv_filters, initial_kernel_size, kernel_initializer='he_normal', padding='same', name='initial_conv2D',
                    use_bias=False, kernel_regularizer=l2(weight_decay))(img_input)
         x = BatchNormalization(axis=concat_axis, epsilon=1.1e-5, name='initial_bn')(x)
         x = Activation('relu')(x)


### PR DESCRIPTION
There is an interesting difference between the densenet and tiramisu papers, densenet uses a mix of max, plus avg pooling in transitions down while tiramisu uses max pooling in transitions down. This should correct each to correspond with their respective papers.

Since DenseNetFCN networks easily become too large to fit in memory on TensorFlow due to https://github.com/tensorflow/tensorflow/issues/12948, I've added an early transition option where the first transition down is before the first dense block. This reduces memory requirements dramatically.