### PR TITLE
Add the SineReLU activation function as an advanced activation.

### DIFF
--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -284,6 +284,7 @@ class Swish(Layer):
 
 get_custom_objects().update({'Swish': Swish})
 
+
 class ReLUs(Layer):
     """Sigmoid version of the Rectified Linear Unit
 

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -312,14 +312,34 @@ class SineReLU(Layer):
         It has been extensively tested with Deep Nets, CNNs, LSTMs, Residual Nets and GANs, based
         on the MNIST, Kaggle Toxicity and IMDB datasets.
         - Performance:
-          - MNIST
-            * Neural Net with 3 Hidden Layers, Dropout, Adam Optimiser
-              - SineReLU: epsilon=0.0083; Final loss: 0.0765; final accuracy: 0.9833; STD loss: 0.05375531819714868
-              - ReLU; Final loss: 0.0823, final accuracy: 0.9829 -> ReLU; STD loss => 0.05736969016884351
+            - MNIST
+              * Neural Net with 3 Dense layers, Dropout, Adam Optimiser, 50 Epochs
+                - SineReLU: epsilon=0.0083; Final loss: 0.0765; final accuracy: 0.9833; STD loss: 0.05375531819714868
+                - ReLU: Final loss: 0.0823, final accuracy: 0.9829; STD loss: 0.05736969016884351
+              * CNN with 5 Conv layers, Dropout, Adam Optimiser, 50 Epochs
+                - SineReLU: CNN epsilon=0.0045; Dense epsilon=0.0083; Final loss: 0.0197, final accuracy: 0.9950; STD loss: 0.03690133793565328
+                - ReLU: Final loss: 0.0203, final accuracy: 0.9939; STD loss: 0.04592196838390996
+            - IMDB
+              * Neural Net with Embedding layer, 2 Dense layers, Dropout, Adam Optimiser, 5 epochs
+                - SineReLU: epsilon=0.0075; Final loss: 0.3268, final accuracy: 0.8590; ROC (AUC): 93.54; STD loss: 0.1763376755356713
+                - ReLU: Final loss: 0.3265, final accuracy: 0.8577; ROC (AUC): 93.54; STD loss: 0.17714072354980567
+              * CNN with Embedding Layer, 1 Conv1D layer, 2 Dense layers, Dropout, Adam Optimiser, 10 epochs
+                - SineReLU: CNN epsilon=0.0025; Dense epsilon=0.0083; Final loss: 0.2868, final accuracy: 0.8783; ROC (AUC): 95.09; STD loss: 0.12384455966040334
+                - ReLU: Final loss: 0.4135, final accuracy: 0.8757; 0.8755; ROC (AUC): 94.85; STD loss: 0.1633409454830405
+        - Jupyter Notebooks
+            - MNIST
+              - Neural Net: https://github.com/ekholabs/DLinK/blob/master/notebooks/keras/intermediate-net-in-keras.ipynb
+              - CNN: https://github.com/ekholabs/DLinK/blob/master/notebooks/keras/conv-net-in-keras.ipynb
+            - IMDB:
+              - Neural Net: https://github.com/ekholabs/DLinK/blob/master/notebooks/nlp/deep_net_sentiment_classifier_for_imdb.ipynb
+              - CNN: https://github.com/ekholabs/DLinK/blob/master/notebooks/nlp/conv_net_sentiment_classifier_for_imdb.ipynb
 
     # Examples
         The Advanced Activation function SineReLU have to be imported from the
         keras_contrib.layers package.
+
+        To load a saved model, add the following to the keras.models.load_model() call:
+          - custom_objects={'SineReLU': SineReLU}
 
         To see full source-code of this architecture and other examples,
         please follow this link: https://github.com/ekholabs/DLinK

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -301,15 +301,25 @@ class ReLUs(Layer):
     # Output shape
         Same shape as the input.
 
-    # Usage
+    # Arguments
+        epsilon: float. Hyper-parameter used to control oscilations when weights are negative.
+                 The default value, 0.0055, work better for Deep Neural Networks. When using CNNs,
+                 try something around 0.0025.
+
+    # References:
+        - ReLUs: An Alternative to the ReLU Activation Function. This function was
+        first introduced at the Codemotion Amsterdam 2018 and then at the DevDays, in Vilnius, Lithuania.
+        It has been extensively tested with Deep Nets, CNNs, LSTMs, Residual Nets and GANs, based
+        on the MNIST, Kaggle Toxicity and IMDB datasets.
+
+    # Examples
         The Advanced Activation function ReLUs have to be imported from the
         keras_contrib.layers package.
 
-        To see full source-code of those architectures and other examples,
+        To see full source-code of this architecture and other examples,
         please follow this link: https://github.com/ekholabs/DLinK
 
-        - Deep Neural Network model example for the MNIST dataset:
-
+        ```python
             model = Sequential()
             model.add(Dense(128, input_shape = (784,)))
             model.add(ReLUs(epsilon=0.0055))
@@ -324,50 +334,7 @@ class ReLUs(Layer):
             model.add(Dropout(0.5))
 
             model.add(Dense(10, activation = 'softmax'))
-
-        - Convolutional Neural Network model example for the MNIST dataset:
-
-            model = Sequential()
-
-            model.add(Conv2D(32, 7, padding = 'same', input_shape = (28, 28, 1)))
-            model.add(ReLUs(0.0025))
-            model.add(Conv2D(32, 7, padding = 'same'))
-            model.add(ReLUs(0.0025))
-            model.add(MaxPooling2D(pool_size = (2, 2)))
-            model.add(Dropout(0.20))
-
-            model.add(Conv2D(64, 3, padding = 'same'))
-            model.add(ReLUs(0.0025))
-            model.add(Conv2D(64, 3, padding = 'same'))
-            model.add(ReLUs(0.0025))
-            model.add(MaxPooling2D(pool_size = (2, 2)))
-            model.add(Dropout(0.30))
-
-            model.add(Conv2D(128, 2, padding = 'same'))
-            model.add(ReLUs(0.0025))
-            model.add(Conv2D(128, 2, padding = 'same'))
-            model.add(ReLUs(0.0025))
-            model.add(MaxPooling2D(pool_size = (2, 2)))
-            model.add(Dropout(0.40))
-
-            model.add(Flatten())
-            model.add(Dense(512))
-            model.add(ReLUs(0.0025))
-            model.add(Dropout(0.50))
-            model.add(Dense(10, activation = "softmax"))
-
-            model.summary()
-
-    # Arguments
-        epsilon: float. Hyper-parameter used to control oscilations when weights are negative.
-                 The default value, 0.0055, work better for Deep Neural Networks. When using CNNs,
-                 try something around 0.0025.
-
-    # References:
-        - ReLUs: An Alternative to the ReLU Activation Function. This function was
-        first introduced at the Codemotion Amsterdam 2018 and then at the DevDays, in Vilnius, Lithuania.
-        It has been extensively tested with Deep Nets, CNNs, LSTMs, Residual Nets and GANs, based
-        on the MNIST, Kaggle Toxicity and IMDB datasets.
+        ```
     """
 
     def __init__(self, epsilon=0.0055, **kwargs):

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -308,7 +308,6 @@ class ReLUs(Layer):
         To see full source-code of those architectures and other examples,
         please follow this link: https://github.com/ekholabs/DLinK
 
-
         - Deep Neural Network model example for the MNIST dataset:
 
             model = Sequential()
@@ -366,7 +365,7 @@ class ReLUs(Layer):
 
     # References:
         - ReLUs: An Alternative to the ReLU Activation Function. This function was
-        first introduced at the Codemotion Amsterdam 2018 and then at the DevDay, in Vilnius, Lithuania.
+        first introduced at the Codemotion Amsterdam 2018 and then at the DevDays, in Vilnius, Lithuania.
         It has been extensively tested with Deep Nets, CNNs, LSTMs, Residual Nets and GANs, based
         on the MNIST, Kaggle Toxicity and IMDB datasets.
     """

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -283,3 +283,50 @@ class Swish(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 get_custom_objects().update({'Swish': Swish})
+
+class ReLUs(Layer):
+    """Sigmoid version of the Rectified Linear Unit
+
+    It allows an oscilation in the gradients when the weights are negative.
+    The oscilation can be controlled with a parameter, which makes it be close
+    or equal to zero. So, not all neurons are deactivated and it allows differentiability
+    in more parts of the function.
+
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+
+    # Output shape
+        Same shape as the input.
+
+    # Arguments
+        epsilon: float. Hyper-parameter used to control oscilations when weights are negative.
+                 The default value, 0.0055, work better for Deep Neural Networks. When using CNNs,
+                 try something around 0.0025.
+
+    # References:
+        - ReLUs: An Alternative to the ReLU Activation Function. This function was
+        first introduced at the Codemotion Amsterdam 2018 and then at the DevDay, in Vilnius, Lithuania.
+        It has been extensively tested with Deep Nets, CNNs, LSTMs, Residual Nets and GANs, based
+        on the MNIST, Kaggle Toxicity and IMDB datasets.
+    """
+
+    def __init__(self, epsilon=0.0055, **kwargs):
+        super(ReLUs, self).__init__(**kwargs)
+        self.supports_masking = True
+        self.epsilon = K.cast_to_floatx(epsilon)
+
+    def call(self, Z):
+        pi = K.variable((np.pi))
+        m = self.epsilon * (K.sigmoid(K.sin(Z)) - K.sigmoid(K.cos(Z)) * K.exp(K.sqrt(pi)))
+        A = K.maximum(m, Z)
+        return A
+
+    def get_config(self):
+        config = {'epsilon': float(self.epsilon)}
+        base_config = super(ReLUs, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def compute_output_shape(self, input_shape):
+        return input_shape

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -286,7 +286,7 @@ get_custom_objects().update({'Swish': Swish})
 
 
 class ReLUs(Layer):
-    """Sigmoid version of the Rectified Linear Unit
+    """Rectified Linear Unit with Sigmoid to generate oscilations.
 
     It allows an oscilation in the gradients when the weights are negative.
     The oscilation can be controlled with a parameter, which makes it be close
@@ -300,6 +300,64 @@ class ReLUs(Layer):
 
     # Output shape
         Same shape as the input.
+
+    # Usage
+        The Advanced Activation function ReLUs have to be imported from the
+        keras_contrib.layers package.
+
+        To see full source-code of those architectures and other examples,
+        please follow this link: https://github.com/ekholabs/DLinK
+
+
+        - Deep Neural Network model example for the MNIST dataset:
+
+            model = Sequential()
+            model.add(Dense(128, input_shape = (784,)))
+            model.add(ReLUs(epsilon=0.0055))
+            model.add(Dropout(0.2))
+
+            model.add(Dense(256))
+            model.add(ReLUs(epsilon=0.0055))
+            model.add(Dropout(0.3))
+
+            model.add(Dense(1024))
+            model.add(ReLUs(epsilon=0.0055))
+            model.add(Dropout(0.5))
+
+            model.add(Dense(10, activation = 'softmax'))
+
+        - Convolutional Neural Network model example for the MNIST dataset:
+
+            model = Sequential()
+
+            model.add(Conv2D(32, 7, padding = 'same', input_shape = (28, 28, 1)))
+            model.add(ReLUs(0.0025))
+            model.add(Conv2D(32, 7, padding = 'same'))
+            model.add(ReLUs(0.0025))
+            model.add(MaxPooling2D(pool_size = (2, 2)))
+            model.add(Dropout(0.20))
+
+            model.add(Conv2D(64, 3, padding = 'same'))
+            model.add(ReLUs(0.0025))
+            model.add(Conv2D(64, 3, padding = 'same'))
+            model.add(ReLUs(0.0025))
+            model.add(MaxPooling2D(pool_size = (2, 2)))
+            model.add(Dropout(0.30))
+
+            model.add(Conv2D(128, 2, padding = 'same'))
+            model.add(ReLUs(0.0025))
+            model.add(Conv2D(128, 2, padding = 'same'))
+            model.add(ReLUs(0.0025))
+            model.add(MaxPooling2D(pool_size = (2, 2)))
+            model.add(Dropout(0.40))
+
+            model.add(Flatten())
+            model.add(Dense(512))
+            model.add(ReLUs(0.0025))
+            model.add(Dropout(0.50))
+            model.add(Dense(10, activation = "softmax"))
+
+            model.summary()
 
     # Arguments
         epsilon: float. Hyper-parameter used to control oscilations when weights are negative.

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -338,9 +338,6 @@ class SineReLU(Layer):
         The Advanced Activation function SineReLU have to be imported from the
         keras_contrib.layers package.
 
-        To load a saved model, add the following to the keras.models.load_model() call:
-          - custom_objects={'SineReLU': SineReLU}
-
         To see full source-code of this architecture and other examples,
         please follow this link: https://github.com/ekholabs/DLinK
 
@@ -383,3 +380,5 @@ class SineReLU(Layer):
 
     def compute_output_shape(self, input_shape):
         return input_shape
+
+get_custom_objects().update({'SineReLU': SineReLU})

--- a/keras_contrib/tests/advanced_activations_test.py
+++ b/keras_contrib/tests/advanced_activations_test.py
@@ -5,9 +5,9 @@ from keras import layers
 
 
 @keras_test
-def test_relus():
+def test_sine_relu():
     for epsilon in [0.0025, 0.0035, 0.0045]:
-        layer_test(layers.ReLUs, kwargs={'epsilon': epsilon},
+        layer_test(layers.SineReLU, kwargs={'epsilon': epsilon},
                    input_shape=(2, 3, 4))
 
 

--- a/keras_contrib/tests/advanced_activations_test.py
+++ b/keras_contrib/tests/advanced_activations_test.py
@@ -1,0 +1,15 @@
+import pytest
+from keras.utils.test_utils import layer_test
+from keras.utils.test_utils import keras_test
+from keras import layers
+
+
+@keras_test
+def test_relus():
+    for epsilon in [0.0025, 0.0035, 0.0045]:
+        layer_test(layers.ReLUs, kwargs={'epsilon': epsilon},
+                   input_shape=(2, 3, 4))
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
The Rectified Linear Unit with Sigmoid has been under development for almost a year now. It has been part of the IBM Watson AI XPRIZE Competition and benchmarked against the ReLU and Leaky ReLU, and still showing better results.

The following data sets were used:

* MNIST
* IMDB
* Kaggle Toxicity

The function will be demonstrated publicly at the Codemotion Amsterdam 2018 Conference and the DevDays in Vilnius, Lithuania. Both conferences are happening in May this year.

Jupyter notebooks using the function are available here: https://github.com/ekholabs/DLinK

Below, some benchmarking against ReLU and Leaky ReLU using Deep Nets and CNNs.

* Deep Net

![image](https://user-images.githubusercontent.com/5129209/37491894-8da2b040-289f-11e8-83bd-5afacde49bbb.png)

* CNN

![image](https://user-images.githubusercontent.com/5129209/37491964-c7ff068a-289f-11e8-9db9-d459282dc141.png)

The function has also showed better results with DQN for the CartPole.v0 and ResNet 50.

Since I'm not linked to any academic institution, it has been proven difficult to make the function open. However, as a follower of the open source movement, I think it should be made available for others to test / use. I hope the Keras community can find a good use for it.