### PR TITLE
Addition of GroupNormalization

### DIFF
--- a/keras_contrib/backend/cntk_backend.py
+++ b/keras_contrib/backend/cntk_backend.py
@@ -30,5 +30,4 @@ def clip(x, min_value, max_value):
 def moments(x, axes, shift=None, keep_dims=False):
     ''' Calculates and returns the mean and variance of the input '''
     mean, variant = KCN._moments(x, axes=axes, shift=shift, keep_dims=keep_dims)
-
     return mean, variant

--- a/keras_contrib/backend/cntk_backend.py
+++ b/keras_contrib/backend/cntk_backend.py
@@ -25,3 +25,11 @@ def clip(x, min_value, max_value):
         min_value = -np.inf
     max_value = C.maximum(min_value, max_value)
     return C.clip(x, min_value, max_value)
+
+
+def moments(x, axes, shift=None, keep_dims=False):
+    ''' Calculates and returns the mean and variance of the input '''
+    mean_batch = KCN.mean(x, axis=axes, keepdims=keep_dims)
+    var_batch = KCN.var(x, axis=axes, keepdims=keep_dims)
+
+    return mean_batch, var_batch

--- a/keras_contrib/backend/cntk_backend.py
+++ b/keras_contrib/backend/cntk_backend.py
@@ -29,7 +29,6 @@ def clip(x, min_value, max_value):
 
 def moments(x, axes, shift=None, keep_dims=False):
     ''' Calculates and returns the mean and variance of the input '''
-    mean_batch = KCN.mean(x, axis=axes, keepdims=keep_dims)
-    var_batch = KCN.var(x, axis=axes, keepdims=keep_dims)
+    mean, variant = KCN._moments(x, axes=axes, shift=shift, keep_dims=keep_dims)
 
-    return mean_batch, var_batch
+    return mean, variant

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -142,6 +142,7 @@ class InstanceNormalization(Layer):
         base_config = super(InstanceNormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+
 get_custom_objects().update({'InstanceNormalization': InstanceNormalization})
 
 
@@ -373,4 +374,188 @@ class BatchRenormalization(Layer):
         base_config = super(BatchRenormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+
 get_custom_objects().update({'BatchRenormalization': BatchRenormalization})
+
+
+class GroupNormalization(Layer):
+    """Group normalization layer
+
+    Group Normalization divides the channels into groups and computes within each group
+    the mean and variance for normalization. GN's computation is independent of batch sizes,
+    and its accuracy is stable in a wide range of batch sizes
+
+    # Arguments
+        groups: Integer, the number of groups for Group Normalization.
+        axis: Integer, the axis that should be normalized
+            (typically the features axis).
+            For instance, after a `Conv2D` layer with
+            `data_format="channels_first"`,
+            set `axis=1` in `BatchNormalization`.
+        epsilon: Small float added to variance to avoid dividing by zero.
+        center: If True, add offset of `beta` to normalized tensor.
+            If False, `beta` is ignored.
+        scale: If True, multiply by `gamma`.
+            If False, `gamma` is not used.
+            When the next layer is linear (also e.g. `nn.relu`),
+            this can be disabled since the scaling
+            will be done by the next layer.
+        beta_initializer: Initializer for the beta weight.
+        gamma_initializer: Initializer for the gamma weight.
+        beta_regularizer: Optional regularizer for the beta weight.
+        gamma_regularizer: Optional regularizer for the gamma weight.
+        beta_constraint: Optional constraint for the beta weight.
+        gamma_constraint: Optional constraint for the gamma weight.
+
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+
+    # Output shape
+        Same shape as input.
+
+    # References
+        - [Group Normalization](https://arxiv.org/abs/1803.08494)
+    """
+
+    def __init__(self,
+                 groups=32,
+                 axis=-1,
+                 epsilon=1e-5,
+                 center=True,
+                 scale=True,
+                 beta_initializer='zeros',
+                 gamma_initializer='ones',
+                 beta_regularizer=None,
+                 gamma_regularizer=None,
+                 beta_constraint=None,
+                 gamma_constraint=None,
+                 **kwargs):
+        super(GroupNormalization, self).__init__(**kwargs)
+        self.supports_masking = True
+        self.groups = groups
+        self.axis = axis
+        self.epsilon = epsilon
+        self.center = center
+        self.scale = scale
+        self.beta_initializer = initializers.get(beta_initializer)
+        self.gamma_initializer = initializers.get(gamma_initializer)
+        self.beta_regularizer = regularizers.get(beta_regularizer)
+        self.gamma_regularizer = regularizers.get(gamma_regularizer)
+        self.beta_constraint = constraints.get(beta_constraint)
+        self.gamma_constraint = constraints.get(gamma_constraint)
+
+    def build(self, input_shape):
+        dim = input_shape[self.axis]
+
+        if dim is None:
+            raise ValueError('Axis ' + str(self.axis) + ' of '
+                                                        'input tensor should have a defined dimension '
+                                                        'but the layer received an input with shape ' +
+                             str(input_shape) + '.')
+
+        if dim < self.groups:
+            raise ValueError('Number of groups (' + str(self.groups) + ') cannot be '
+                                                                       'more than the number of channels (' +
+                             str(dim) + ').')
+
+        if dim % self.groups != 0:
+            raise ValueError('Number of groups (' + str(self.groups) + ') must be a '
+                                                                       'multiple of the number of channels (' +
+                             str(dim) + ').')
+
+        self.input_spec = InputSpec(ndim=len(input_shape),
+                                    axes={self.axis: dim})
+        shape = (dim,)
+
+        if self.scale:
+            self.gamma = self.add_weight(shape=shape,
+                                         name='gamma',
+                                         initializer=self.gamma_initializer,
+                                         regularizer=self.gamma_regularizer,
+                                         constraint=self.gamma_constraint)
+        else:
+            self.gamma = None
+        if self.center:
+            self.beta = self.add_weight(shape=shape,
+                                        name='beta',
+                                        initializer=self.beta_initializer,
+                                        regularizer=self.beta_regularizer,
+                                        constraint=self.beta_constraint)
+        else:
+            self.beta = None
+        self.built = True
+
+    def call(self, inputs, **kwargs):
+        input_shape = K.int_shape(inputs)
+        # Prepare broadcasting shape.
+        ndim = len(input_shape)
+        reduction_axes = list(range(len(input_shape)))
+        del reduction_axes[self.axis]
+        broadcast_shape = [1] * len(input_shape)
+        broadcast_shape[self.axis] = input_shape[self.axis]
+
+        reshape_group_shape = list(input_shape)
+        reshape_group_shape[self.axis] = input_shape[self.axis] // self.groups
+        group_shape = [-1, self.groups]
+        group_shape.extend(reshape_group_shape[1:])
+        group_reduction_axes = list(range(len(group_shape)))
+
+        # Determines whether broadcasting is needed.
+        needs_broadcasting = (sorted(reduction_axes) != list(range(ndim))[:-1])
+
+        inputs = K.reshape(inputs, group_shape)
+
+        mean = K.mean(inputs, axis=group_reduction_axes[2:], keepdims=True)
+        varience = K.var(inputs, axis=group_reduction_axes[2:], keepdims=True)
+
+        inputs = (inputs - mean) / (K.sqrt(varience + self.epsilon))
+
+        original_shape = [-1] + list(input_shape[1:])
+        inputs = K.reshape(inputs, original_shape)
+
+        if needs_broadcasting:
+            outputs = inputs
+
+            # In this case we must explicitly broadcast all parameters.
+            if self.scale:
+                broadcast_gamma = K.reshape(self.gamma, broadcast_shape)
+                outputs = outputs * broadcast_gamma
+
+            if self.center:
+                broadcast_beta = K.reshape(self.beta, broadcast_shape)
+                outputs = outputs + broadcast_beta
+        else:
+            outputs = inputs
+
+            if self.scale:
+                outputs = outputs + self.beta
+
+            if self.center:
+                outputs = outputs * self.gamma
+
+        return outputs
+
+    def get_config(self):
+        config = {
+            'groups': self.groups,
+            'axis': self.axis,
+            'epsilon': self.epsilon,
+            'center': self.center,
+            'scale': self.scale,
+            'beta_initializer': initializers.serialize(self.beta_initializer),
+            'gamma_initializer': initializers.serialize(self.gamma_initializer),
+            'beta_regularizer': regularizers.serialize(self.beta_regularizer),
+            'gamma_regularizer': regularizers.serialize(self.gamma_regularizer),
+            'beta_constraint': constraints.serialize(self.beta_constraint),
+            'gamma_constraint': constraints.serialize(self.gamma_constraint)
+        }
+        base_config = super(GroupNormalization, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+
+get_custom_objects().update({'GroupNormalization': GroupNormalization})

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -527,11 +527,11 @@ class GroupNormalization(Layer):
         else:
             outputs = inputs
 
-            if self.scale:
-                outputs = outputs + self.beta
-
             if self.center:
                 outputs = outputs * self.gamma
+
+            if self.scale:
+                outputs = outputs + self.beta
 
         return outputs
 

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -527,10 +527,10 @@ class GroupNormalization(Layer):
         else:
             outputs = inputs
 
-            if self.center:
+            if self.scale:
                 outputs = outputs * self.gamma
 
-            if self.scale:
+            if self.center:
                 outputs = outputs + self.beta
 
         return outputs

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -382,11 +382,21 @@ class GroupNormalization(Layer):
     """Group normalization layer
 
     Group Normalization divides the channels into groups and computes within each group
-    the mean and variance for normalization. GN's computation is independent of batch sizes,
-    and its accuracy is stable in a wide range of batch sizes
+    the mean and variance for normalization. Group Normalization's computation is independent
+     of batch sizes, and its accuracy is stable in a wide range of batch sizes.
+
+    Relation to Layer Normalization:
+    If the number of groups is set to 1, then this operation becomes identical to
+    Layer Normalization.
+
+    Relation to Instance Normalization:
+    If the number of groups is set to the input dimension (number of groups is equal
+    to number of channels), then this operation becomes identical to Instance Normalization.
 
     # Arguments
         groups: Integer, the number of groups for Group Normalization.
+            Can be in the range [1, N] where N is the input dimension.
+            The input dimension must be divisible by the number of groups.
         axis: Integer, the axis that should be normalized
             (typically the features axis).
             For instance, after a `Conv2D` layer with

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -451,18 +451,18 @@ class GroupNormalization(Layer):
 
         if dim is None:
             raise ValueError('Axis ' + str(self.axis) + ' of '
-                                                        'input tensor should have a defined dimension '
-                                                        'but the layer received an input with shape ' +
+                             'input tensor should have a defined dimension '
+                             'but the layer received an input with shape ' +
                              str(input_shape) + '.')
 
         if dim < self.groups:
             raise ValueError('Number of groups (' + str(self.groups) + ') cannot be '
-                                                                       'more than the number of channels (' +
+                             'more than the number of channels (' +
                              str(dim) + ').')
 
         if dim % self.groups != 0:
             raise ValueError('Number of groups (' + str(self.groups) + ') must be a '
-                                                                       'multiple of the number of channels (' +
+                             'multiple of the number of channels (' +
                              str(dim) + ').')
 
         self.input_spec = InputSpec(ndim=len(input_shape),

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -507,10 +507,8 @@ class GroupNormalization(Layer):
 
         inputs = K.reshape(inputs, group_shape)
 
-        mean = K.mean(inputs, axis=group_reduction_axes[2:], keepdims=True)
-        varience = K.var(inputs, axis=group_reduction_axes[2:], keepdims=True)
-
-        inputs = (inputs - mean) / (K.sqrt(varience + self.epsilon))
+        mean, variance = K.moments(inputs, group_reduction_axes[2:], keep_dims=True)
+        inputs = (inputs - mean) / (K.sqrt(variance + self.epsilon))
 
         original_shape = [-1] + list(input_shape[1:])
         inputs = K.reshape(inputs, original_shape)

--- a/tests/keras_contrib/backend/backend_test.py
+++ b/tests/keras_contrib/backend/backend_test.py
@@ -5,11 +5,11 @@ import numpy as np
 from keras import backend as K
 from keras.backend import theano_backend as KTH, floatx, set_floatx, variable
 from keras.backend import tensorflow_backend as KTF
-# from keras.backend import cntk_backend as KCTK
+from keras.backend import cntk_backend as KCTK
 from keras_contrib import backend as KC
 import keras_contrib.backend.theano_backend as KCTH
 import keras_contrib.backend.tensorflow_backend as KCTF
-# import keras_contrib.backend.cntk_backend as KCNTK
+import keras_contrib.backend.cntk_backend as KCNTK
 from keras.utils.conv_utils import convert_kernel
 
 
@@ -153,21 +153,21 @@ class TestBackend(object):
                     ip_tf = KTF.variable(ip)
                     tf_mean, tf_var = KCTF.moments(ip_tf, axes, keep_dims=keep_dims)
 
-                    # ip_cntk = KCTK.variable(ip)
-                    # cntk_mean, cntk_var = KCNTK.moments(ip_cntk, axes, keep_dims=keep_dims)
+                    ip_cntk = KCTK.variable(ip)
+                    cntk_mean, cntk_var = KCNTK.moments(ip_cntk, axes, keep_dims=keep_dims)
 
                     th_mean_val = KTH.eval(th_mean)
                     tf_mean_val = KTF.eval(tf_mean)
-                    # cntk_mean_val = KCTK.eval(cntk_mean)
+                    cntk_mean_val = KCTK.eval(cntk_mean)
                     th_var_val = KTH.eval(th_var)
                     tf_var_val = KTF.eval(tf_var)
-                    # cntk_var_val = KCTK.eval(cntk_var)
+                    cntk_var_val = KCTK.eval(cntk_var)
 
                     # absolute tolerance needed when working with zeros
                     assert_allclose(th_mean_val, tf_mean_val, rtol=1e-4, atol=1e-10)
                     assert_allclose(th_var_val, tf_var_val, rtol=1e-4, atol=1e-10)
-                    # assert_allclose(th_mean_val, cntk_mean_val, rtol=1e-4, atol=1e-10)
-                    # assert_allclose(th_var_val, cntk_var_val, rtol=1e-4, atol=1e-10)
+                    assert_allclose(th_mean_val, cntk_mean_val, rtol=1e-4, atol=1e-10)
+                    assert_allclose(th_var_val, cntk_var_val, rtol=1e-4, atol=1e-10)
 
     def test_clip(self):
         check_single_tensor_operation('clip', (4, 2), min_value=0.4, max_value=0.6)

--- a/tests/keras_contrib/backend/backend_test.py
+++ b/tests/keras_contrib/backend/backend_test.py
@@ -5,9 +5,11 @@ import numpy as np
 from keras import backend as K
 from keras.backend import theano_backend as KTH, floatx, set_floatx, variable
 from keras.backend import tensorflow_backend as KTF
+from keras.backend import cntk_backend as KCTK
 from keras_contrib import backend as KC
 import keras_contrib.backend.theano_backend as KCTH
 import keras_contrib.backend.tensorflow_backend as KCTF
+import keras_contrib.backend.cntk_backend as KCNTK
 from keras.utils.conv_utils import convert_kernel
 
 
@@ -141,6 +143,7 @@ class TestBackend(object):
 
         th_axes = [0, 2, 3]
         tf_axes = [0, 1, 2]
+        cntk_axes = [0, 1, 2]
 
         for ip in [x_0, x_1, x_random]:
             for axes in [th_axes, tf_axes]:
@@ -151,14 +154,21 @@ class TestBackend(object):
                     ip_tf = KTF.variable(ip)
                     tf_mean, tf_var = KCTF.moments(ip_tf, axes, keep_dims=keep_dims)
 
+                    ip_cntk = KCTK.variable(ip)
+                    cntk_mean, cntk_var = KCNTK.moments(ip_cntk, axes, keep_dims=keep_dims)
+
                     th_mean_val = KTH.eval(th_mean)
                     tf_mean_val = KTF.eval(tf_mean)
+                    cntk_mean_val = KCTK.eval(cntk_mean)
                     th_var_val = KTH.eval(th_var)
                     tf_var_val = KTF.eval(tf_var)
+                    cntk_var_val = KCTK.eval(cntk_var)
 
                     # absolute tolerance needed when working with zeros
                     assert_allclose(th_mean_val, tf_mean_val, rtol=1e-4, atol=1e-10)
                     assert_allclose(th_var_val, tf_var_val, rtol=1e-4, atol=1e-10)
+                    assert_allclose(th_mean_val, cntk_mean_val, rtol=1e-4, atol=1e-10)
+                    assert_allclose(th_var_val, cntk_var_val, rtol=1e-4, atol=1e-10)
 
     def test_clip(self):
         check_single_tensor_operation('clip', (4, 2), min_value=0.4, max_value=0.6)

--- a/tests/keras_contrib/backend/backend_test.py
+++ b/tests/keras_contrib/backend/backend_test.py
@@ -5,11 +5,11 @@ import numpy as np
 from keras import backend as K
 from keras.backend import theano_backend as KTH, floatx, set_floatx, variable
 from keras.backend import tensorflow_backend as KTF
-from keras.backend import cntk_backend as KCTK
+# from keras.backend import cntk_backend as KCTK
 from keras_contrib import backend as KC
 import keras_contrib.backend.theano_backend as KCTH
 import keras_contrib.backend.tensorflow_backend as KCTF
-import keras_contrib.backend.cntk_backend as KCNTK
+# import keras_contrib.backend.cntk_backend as KCNTK
 from keras.utils.conv_utils import convert_kernel
 
 
@@ -143,7 +143,6 @@ class TestBackend(object):
 
         th_axes = [0, 2, 3]
         tf_axes = [0, 1, 2]
-        cntk_axes = [0, 1, 2]
 
         for ip in [x_0, x_1, x_random]:
             for axes in [th_axes, tf_axes]:
@@ -154,21 +153,21 @@ class TestBackend(object):
                     ip_tf = KTF.variable(ip)
                     tf_mean, tf_var = KCTF.moments(ip_tf, axes, keep_dims=keep_dims)
 
-                    ip_cntk = KCTK.variable(ip)
-                    cntk_mean, cntk_var = KCNTK.moments(ip_cntk, axes, keep_dims=keep_dims)
+                    # ip_cntk = KCTK.variable(ip)
+                    # cntk_mean, cntk_var = KCNTK.moments(ip_cntk, axes, keep_dims=keep_dims)
 
                     th_mean_val = KTH.eval(th_mean)
                     tf_mean_val = KTF.eval(tf_mean)
-                    cntk_mean_val = KCTK.eval(cntk_mean)
+                    # cntk_mean_val = KCTK.eval(cntk_mean)
                     th_var_val = KTH.eval(th_var)
                     tf_var_val = KTF.eval(tf_var)
-                    cntk_var_val = KCTK.eval(cntk_var)
+                    # cntk_var_val = KCTK.eval(cntk_var)
 
                     # absolute tolerance needed when working with zeros
                     assert_allclose(th_mean_val, tf_mean_val, rtol=1e-4, atol=1e-10)
                     assert_allclose(th_var_val, tf_var_val, rtol=1e-4, atol=1e-10)
-                    assert_allclose(th_mean_val, cntk_mean_val, rtol=1e-4, atol=1e-10)
-                    assert_allclose(th_var_val, cntk_var_val, rtol=1e-4, atol=1e-10)
+                    # assert_allclose(th_mean_val, cntk_mean_val, rtol=1e-4, atol=1e-10)
+                    # assert_allclose(th_var_val, cntk_var_val, rtol=1e-4, atol=1e-10)
 
     def test_clip(self):
         check_single_tensor_operation('clip', (4, 2), min_value=0.4, max_value=0.6)

--- a/tests/keras_contrib/layers/test_normalization.py
+++ b/tests/keras_contrib/layers/test_normalization.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from keras.layers import Dense, Activation, Input
+from keras import regularizers
 from keras.utils.test_utils import layer_test, keras_test
 from keras_contrib.layers import normalization
 from keras.models import Sequential, Model
@@ -335,6 +336,236 @@ def test_batchrenorm_get_config():
     y = normalization.BatchRenormalization()(x)
     model = Model(x, y)
     model.get_config()
+
+
+@keras_test
+def test_basic_groupnorm():
+    layer_test(normalization.GroupNormalization,
+               kwargs={'groups': 2,
+                       'epsilon': 0.1,
+                       'gamma_regularizer': regularizers.l2(0.01),
+                       'beta_regularizer': regularizers.l2(0.01)},
+               input_shape=(3, 4, 2))
+    layer_test(normalization.GroupNormalization,
+               kwargs={'groups': 2,
+                       'epsilon': 0.1,
+                       'axis': 1},
+               input_shape=(3, 4, 2))
+    layer_test(normalization.GroupNormalization,
+               kwargs={'groups': 2,
+                       'gamma_initializer': 'ones',
+                       'beta_initializer': 'ones'},
+               input_shape=(3, 4, 2, 4))
+    if K.backend() != 'theano':
+        layer_test(normalization.GroupNormalization,
+                   kwargs={'groups': 2,
+                           'axis': 1,
+                           'scale': False,
+                           'center': False},
+                   input_shape=(3, 4, 2, 4))
+
+
+@keras_test
+def test_groupnorm_correctness_1d():
+    model = Sequential()
+    norm = normalization.GroupNormalization(input_shape=(10,), groups=2)
+    model.add(norm)
+    model.compile(loss='mse', optimizer='rmsprop')
+
+    # centered on 5.0, variance 10.0
+    x = np.random.normal(loc=5.0, scale=10.0, size=(1000, 10))
+    model.fit(x, x, epochs=5, verbose=0)
+    out = model.predict(x)
+    out -= K.eval(norm.beta)
+    out /= K.eval(norm.gamma)
+
+    assert_allclose(out.mean(), 0.0, atol=1e-1)
+    assert_allclose(out.std(), 1.0, atol=1e-1)
+
+
+@keras_test
+def test_groupnorm_correctness_2d():
+    model = Sequential()
+    norm = normalization.GroupNormalization(axis=1, input_shape=(10, 6), groups=2)
+    model.add(norm)
+    model.compile(loss='mse', optimizer='rmsprop')
+
+    # centered on 5.0, variance 10.0
+    x = np.random.normal(loc=5.0, scale=10.0, size=(1000, 10, 6))
+    model.fit(x, x, epochs=5, verbose=0)
+    out = model.predict(x)
+    out -= np.reshape(K.eval(norm.beta), (1, 10, 1))
+    out /= np.reshape(K.eval(norm.gamma), (1, 10, 1))
+
+    assert_allclose(out.mean(axis=(0, 2)), 0.0, atol=1.1e-1)
+    assert_allclose(out.std(axis=(0, 2)), 1.0, atol=1.1e-1)
+
+
+@keras_test
+def test_groupnorm_correctness_2d_different_groups():
+    norm1 = normalization.GroupNormalization(axis=1, input_shape=(10, 6), groups=2)
+    norm2 = normalization.GroupNormalization(axis=1, input_shape=(10, 6), groups=1)
+    norm3 = normalization.GroupNormalization(axis=1, input_shape=(10, 6), groups=10)
+
+    model = Sequential()
+    model.add(norm1)
+    model.compile(loss='mse', optimizer='rmsprop')
+
+    # centered on 5.0, variance 10.0
+    x = np.random.normal(loc=5.0, scale=10.0, size=(1000, 10, 6))
+    model.fit(x, x, epochs=5, verbose=0)
+    out = model.predict(x)
+    out -= np.reshape(K.eval(norm1.beta), (1, 10, 1))
+    out /= np.reshape(K.eval(norm1.gamma), (1, 10, 1))
+
+    assert_allclose(out.mean(axis=(0, 2)), 0.0, atol=1.1e-1)
+    assert_allclose(out.std(axis=(0, 2)), 1.0, atol=1.1e-1)
+
+    model = Sequential()
+    model.add(norm2)
+    model.compile(loss='mse', optimizer='rmsprop')
+
+    # centered on 5.0, variance 10.0
+    x = np.random.normal(loc=5.0, scale=10.0, size=(1000, 10, 6))
+    model.fit(x, x, epochs=5, verbose=0)
+    out = model.predict(x)
+    out -= np.reshape(K.eval(norm2.beta), (1, 10, 1))
+    out /= np.reshape(K.eval(norm2.gamma), (1, 10, 1))
+
+    assert_allclose(out.mean(axis=(0, 2)), 0.0, atol=1.1e-1)
+    assert_allclose(out.std(axis=(0, 2)), 1.0, atol=1.1e-1)
+
+    model = Sequential()
+    model.add(norm3)
+    model.compile(loss='mse', optimizer='rmsprop')
+
+    # centered on 5.0, variance 10.0
+    x = np.random.normal(loc=5.0, scale=10.0, size=(1000, 10, 6))
+    model.fit(x, x, epochs=5, verbose=0)
+    out = model.predict(x)
+    out -= np.reshape(K.eval(norm3.beta), (1, 10, 1))
+    out /= np.reshape(K.eval(norm3.gamma), (1, 10, 1))
+
+    assert_allclose(out.mean(axis=(0, 2)), 0.0, atol=1.1e-1)
+    assert_allclose(out.std(axis=(0, 2)), 1.0, atol=1.1e-1)
+
+
+@keras_test
+def test_groupnorm_mode_twice():
+    # This is a regression test for issue #4881 with the old
+    # batch normalization functions in the Theano backend.
+    model = Sequential()
+    model.add(normalization.GroupNormalization(input_shape=(10, 5, 5), axis=1, groups=2))
+    model.add(normalization.GroupNormalization(input_shape=(10, 5, 5), axis=1, groups=2))
+    model.compile(loss='mse', optimizer='sgd')
+
+    x = np.random.normal(loc=5.0, scale=10.0, size=(20, 10, 5, 5))
+    model.fit(x, x, epochs=1, verbose=0)
+    model.predict(x)
+
+
+@keras_test
+def test_groupnorm_convnet():
+    model = Sequential()
+    norm = normalization.GroupNormalization(axis=1, input_shape=(3, 4, 4), groups=3)
+    model.add(norm)
+    model.compile(loss='mse', optimizer='sgd')
+
+    # centered on 5.0, variance 10.0
+    x = np.random.normal(loc=5.0, scale=10.0, size=(1000, 3, 4, 4))
+    model.fit(x, x, epochs=4, verbose=0)
+    out = model.predict(x)
+    out -= np.reshape(K.eval(norm.beta), (1, 3, 1, 1))
+    out /= np.reshape(K.eval(norm.gamma), (1, 3, 1, 1))
+
+    assert_allclose(np.mean(out, axis=(0, 2, 3)), 0.0, atol=1e-1)
+    assert_allclose(np.std(out, axis=(0, 2, 3)), 1.0, atol=1e-1)
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() == 'theano'),
+                    reason='Bug with theano backend')
+def test_groupnorm_convnet_no_center_no_scale():
+    model = Sequential()
+    norm = normalization.GroupNormalization(axis=-1, center=False, scale=False,
+                                            input_shape=(3, 4, 4), groups=2)
+    model.add(norm)
+    model.compile(loss='mse', optimizer='sgd')
+
+    # centered on 5.0, variance 10.0
+    x = np.random.normal(loc=5.0, scale=10.0, size=(1000, 3, 4, 4))
+    model.fit(x, x, epochs=4, verbose=0)
+    out = model.predict(x)
+
+    assert_allclose(np.mean(out, axis=(0, 2, 3)), 0.0, atol=1e-1)
+    assert_allclose(np.std(out, axis=(0, 2, 3)), 1.0, atol=1e-1)
+
+
+@keras_test
+def test_shared_groupnorm():
+    '''Test that a GN layer can be shared
+    across different data streams.
+    '''
+    # Test single layer reuse
+    bn = normalization.GroupNormalization(input_shape=(10,), groups=2)
+    x1 = Input(shape=(10,))
+    bn(x1)
+
+    x2 = Input(shape=(10,))
+    y2 = bn(x2)
+
+    x = np.random.normal(loc=5.0, scale=10.0, size=(2, 10))
+    model = Model(x2, y2)
+    assert len(model.updates) == 0
+    model.compile('sgd', 'mse')
+    model.train_on_batch(x, x)
+
+    # Test model-level reuse
+    x3 = Input(shape=(10,))
+    y3 = model(x3)
+    new_model = Model(x3, y3)
+    assert len(model.updates) == 0
+    new_model.compile('sgd', 'mse')
+    new_model.train_on_batch(x, x)
+
+
+@keras_test
+def test_that_trainable_disables_updates():
+    val_a = np.random.random((10, 4))
+    val_out = np.random.random((10, 4))
+
+    a = Input(shape=(4,))
+    layer = normalization.GroupNormalization(input_shape=(4,), groups=2)
+    b = layer(a)
+    model = Model(a, b)
+
+    model.trainable = False
+    assert len(model.updates) == 0
+
+    model.compile('sgd', 'mse')
+    assert len(model.updates) == 0
+
+    x1 = model.predict(val_a)
+    model.train_on_batch(val_a, val_out)
+    x2 = model.predict(val_a)
+    assert_allclose(x1, x2, atol=1e-7)
+
+    model.trainable = True
+    model.compile('sgd', 'mse')
+    assert len(model.updates) == 0
+
+    model.train_on_batch(val_a, val_out)
+    x2 = model.predict(val_a)
+    assert np.abs(np.sum(x1 - x2)) > 1e-5
+
+    layer.trainable = False
+    model.compile('sgd', 'mse')
+    assert len(model.updates) == 0
+
+    x1 = model.predict(val_a)
+    model.train_on_batch(val_a, val_out)
+    x2 = model.predict(val_a)
+    assert_allclose(x1, x2, atol=1e-7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds Group Normalization + associated tests from the paper [Group Normalization](https://arxiv.org/abs/1803.08494)

By extention, setting the parameter "groups" to 1 should make it equivalent to Instance Normalization and settng "groups" to the number of input channels will apply layer normalization.