### PR TITLE
Import Numpy so it can be used in the SineReLU activation.

### DIFF
--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -1,3 +1,4 @@
+import numpy as np
 from .. import initializers
 from .. import regularizers
 from .. import constraints


### PR DESCRIPTION
My apologies for the nasty mistake, but I don't know why it was not picked in the test I wrote.

Since I was testing the function in a notebook, not importing it from the branch, I did not get the import error. Now that I build a docker image with the latest Keras-Contrib master, it popped up when I tried to use it.

I built the keras-contrib locally and did an import in the python console to cover it:

```
>>> from keras_contrib.layers.advanced_activations import SineReLU
>>> SineReLU(0.005)
<keras_contrib.layers.advanced_activations.SineReLU object at 0x110214630>
>>> 
```

This change should make it ready for use.

Sorry again and thanks for your time.