### PR TITLE
remove legacy support to conform with keras master

### DIFF
--- a/keras_contrib/utils/save_load_utils.py
+++ b/keras_contrib/utils/save_load_utils.py
@@ -28,10 +28,7 @@ def save_all_weights(model, filepath, include_optimizer=True):
 
     with h5py.File(filepath, 'w') as f:
         model_weights_group = f.create_group('model_weights')
-        if legacy_models.needs_legacy_support(model):
-            model_layers = legacy_models.legacy_sequential_layers(model)
-        else:
-            model_layers = model.layers
+        model_layers = model.layers
         saving.save_weights_to_hdf5_group(model_weights_group, model_layers)
 
         if include_optimizer and hasattr(model, 'optimizer') and model.optimizer:

--- a/keras_contrib/utils/save_load_utils.py
+++ b/keras_contrib/utils/save_load_utils.py
@@ -4,7 +4,6 @@ import h5py
 import keras.backend as K
 from keras import optimizers
 from keras.engine import saving
-from keras.legacy import models as legacy_models
 
 
 def save_all_weights(model, filepath, include_optimizer=True):


### PR DESCRIPTION
Updating keras-contrib to no longer use the models legacy code, since it has been moved or removed. This means legacy (1.x?) models will no longer load and save with load_all_weights and save_all_weights.

https://github.com/keras-team/keras/commit/a637960fab61b66848a36e6a5caf0204c155af01
https://github.com/keras-team/keras/pull/10077

replaces #256