### PR TITLE
Improve the SineReLU activation function

### DIFF
--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -291,8 +291,8 @@ class SineReLU(Layer):
 
     It allows an oscilation in the gradients when the weights are negative.
     The oscilation can be controlled with a parameter, which makes it be close
-    or equal to zero. So, not all neurons are deactivated and it allows differentiability
-    in more parts of the function.
+    or equal to zero. The functional is diferentiable at any point due to its derivative.
+    For instance, at 0, the derivative of 'sin(0) - cos(0)' is 'cos(0) + sin(0)' which is 1.
 
     # Input shape
         Arbitrary. Use the keyword argument `input_shape`
@@ -303,9 +303,9 @@ class SineReLU(Layer):
         Same shape as the input.
 
     # Arguments
-        epsilon: float. Hyper-parameter used to control oscilations when weights are negative.
-                 The default value, 0.0055, work better for Deep Neural Networks. When using CNNs,
-                 try something around 0.0025.
+        epsilon: float. Hyper-parameter used to control the amplitude of the sinusoidal wave when weights are negative.
+                 The default value, 0.0025, since it works better for CNN layers and those are the most used layers nowadays.
+                 When using Dense Networks, try something around 0.0055.
 
     # References:
         - SineReLU: An Alternative to the ReLU Activation Function. This function was
@@ -314,12 +314,12 @@ class SineReLU(Layer):
         on the MNIST, Kaggle Toxicity and IMDB datasets.
         - Performance:
             - MNIST
-              * Neural Net with 3 Dense layers, Dropout, Adam Optimiser, 50 Epochs
-                - SineReLU: epsilon=0.0083; Final loss: 0.0765; final accuracy: 0.9833; STD loss: 0.05375531819714868
-                - ReLU: Final loss: 0.0823, final accuracy: 0.9829; STD loss: 0.05736969016884351
+              * Neural Net with 3 Dense layers, Dropout, Adam Optimiser, 40 Epochs
+                - SineReLU: epsilon=0.0055; Final loss: 0.0593; final accuracy: 0.9859; STD loss: 0.06083421864087177
+                - ReLU: Final loss: 0.0623, final accuracy: 0.9851; STD loss: 0.060961214946358235
               * CNN with 5 Conv layers, Dropout, Adam Optimiser, 50 Epochs
-                - SineReLU: CNN epsilon=0.0045; Dense epsilon=0.0083; Final loss: 0.0197, final accuracy: 0.9950; STD loss: 0.03690133793565328
-                - ReLU: Final loss: 0.0203, final accuracy: 0.9939; STD loss: 0.04592196838390996
+                - SineReLU: CNN epsilon=0.0025; Dense epsilon=0.025; Final loss: 0.0165, final accuracy: 0.9955; STD loss: 0.031123579642053544
+                - ReLU: Final loss: 0.0198, final accuracy: 0.9953; STD loss: 0.0513015402055947
             - IMDB
               * Neural Net with Embedding layer, 2 Dense layers, Dropout, Adam Optimiser, 5 epochs
                 - SineReLU: epsilon=0.0075; Final loss: 0.3268, final accuracy: 0.8590; ROC (AUC): 93.54; STD loss: 0.1763376755356713
@@ -345,32 +345,28 @@ class SineReLU(Layer):
         ```python
             model = Sequential()
             model.add(Dense(128, input_shape = (784,)))
-            model.add(SineReLU(epsilon=0.0083))
+            model.add(SineReLU())
             model.add(Dropout(0.2))
 
             model.add(Dense(256))
-            model.add(SineReLU(epsilon=0.0083))
+            model.add(SineReLU())
             model.add(Dropout(0.3))
 
             model.add(Dense(1024))
-            model.add(SineReLU(epsilon=0.0083))
+            model.add(SineReLU())
             model.add(Dropout(0.5))
 
             model.add(Dense(10, activation = 'softmax'))
         ```
     """
 
-    def __init__(self, epsilon=0.0055, **kwargs):
+    def __init__(self, epsilon=0.0025, **kwargs):
         super(SineReLU, self).__init__(**kwargs)
         self.supports_masking = True
         self.epsilon = K.cast_to_floatx(epsilon)
 
-    def build(self, input_shape):
-        self.scale = np.exp(np.sqrt(np.pi))
-        super(SineReLU, self).build(input_shape)
-
     def call(self, Z):
-        m = self.epsilon * (K.sigmoid(K.sin(Z)) - K.sigmoid(K.cos(Z)) * self.scale)
+        m = self.epsilon * (K.sin(Z) - K.cos(Z))
         A = K.maximum(m, Z)
         return A
 

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -305,35 +305,39 @@ class SineReLU(Layer):
     # Arguments
         epsilon: float. Hyper-parameter used to control the amplitude of the sinusoidal wave when weights are negative.
                  The default value, 0.0025, since it works better for CNN layers and those are the most used layers nowadays.
-                 When using Dense Networks, try something around 0.0055.
+                 When using Dense Networks, try something around 0.006.
 
     # References:
         - SineReLU: An Alternative to the ReLU Activation Function. This function was
         first introduced at the Codemotion Amsterdam 2018 and then at the DevDays, in Vilnius, Lithuania.
         It has been extensively tested with Deep Nets, CNNs, LSTMs, Residual Nets and GANs, based
         on the MNIST, Kaggle Toxicity and IMDB datasets.
-        - Performance:
-            - MNIST
-              * Neural Net with 3 Dense layers, Dropout, Adam Optimiser, 40 Epochs
-                - SineReLU: epsilon=0.0055; Final loss: 0.0593; final accuracy: 0.9859; STD loss: 0.06083421864087177
-                - ReLU: Final loss: 0.0623, final accuracy: 0.9851; STD loss: 0.060961214946358235
-              * CNN with 5 Conv layers, Dropout, Adam Optimiser, 50 Epochs
-                - SineReLU: CNN epsilon=0.0025; Dense epsilon=0.025; Final loss: 0.0165, final accuracy: 0.9955; STD loss: 0.031123579642053544
-                - ReLU: Final loss: 0.0198, final accuracy: 0.9953; STD loss: 0.0513015402055947
-            - IMDB
-              * Neural Net with Embedding layer, 2 Dense layers, Dropout, Adam Optimiser, 5 epochs
-                - SineReLU: epsilon=0.0075; Final loss: 0.3268, final accuracy: 0.8590; ROC (AUC): 93.54; STD loss: 0.1763376755356713
-                - ReLU: Final loss: 0.3265, final accuracy: 0.8577; ROC (AUC): 93.54; STD loss: 0.17714072354980567
-              * CNN with Embedding Layer, 1 Conv1D layer, 2 Dense layers, Dropout, Adam Optimiser, 10 epochs
-                - SineReLU: CNN epsilon=0.0025; Dense epsilon=0.0083; Final loss: 0.2868, final accuracy: 0.8783; ROC (AUC): 95.09; STD loss: 0.12384455966040334
-                - ReLU: Final loss: 0.4135, final accuracy: 0.8757; 0.8755; ROC (AUC): 94.85; STD loss: 0.1633409454830405
-        - Jupyter Notebooks
-            - MNIST
-              - Neural Net: https://github.com/ekholabs/DLinK/blob/master/notebooks/keras/intermediate-net-in-keras.ipynb
-              - CNN: https://github.com/ekholabs/DLinK/blob/master/notebooks/keras/conv-net-in-keras.ipynb
-            - IMDB:
-              - Neural Net: https://github.com/ekholabs/DLinK/blob/master/notebooks/nlp/deep_net_sentiment_classifier_for_imdb.ipynb
-              - CNN: https://github.com/ekholabs/DLinK/blob/master/notebooks/nlp/conv_net_sentiment_classifier_for_imdb.ipynb
+
+    # Performance:
+
+        - Fashion MNIST
+          * Mean of 6 runs per Activation Function
+            * Fully Connection Network
+              - SineReLU: loss mean -> 0.3522; accuracy mean -> 89.18; mean of std loss -> 0.08375204467435822
+              - LeakyReLU: loss mean-> 0.3553; accuracy mean -> 88.98; mean of std loss -> 0.0831161868455245
+              - ReLU: loss mean -> 0.3519; accuracy mean -> 88.84; mean of std loss -> 0.08358816501301362
+            * Convolutional Neural Network
+              - SineReLU: loss mean -> 0.2180; accuracy mean -> 92.49; mean of std loss -> 0.0781155784858847
+              - LeakyReLU: loss mean -> 0.2205; accuracy mean -> 92.37; mean of std loss -> 0.09273670474788205
+              - ReLU: loss mean -> 0.2144; accuracy mean -> 92.45; mean of std loss -> 0.09396114585977
+        - MNIST
+          * Mean of 6 runs per Activation Function
+            * Fully Connection Network
+              - SineReLU: loss mean -> 0.0623; accuracy mean -> 98.53; mean of std loss -> 0.06012015231824904
+              - LeakyReLU: loss mean-> 0.0623; accuracy mean -> 98.50; mean of std loss -> 0.06052147632835356
+              - ReLU: loss mean -> 0.0605; accuracy mean -> 98.49; mean of std loss -> 0.059599885665016096
+            * Convolutional Neural Network
+              - SineReLU: loss mean -> 0.0198; accuracy mean -> 99.51; mean of std loss -> 0.0425338329550847
+              - LeakyReLU: loss mean -> 0.0216; accuracy mean -> 99.40; mean of std loss -> 0.04834468835196667
+              - ReLU: loss mean -> 0.0185; accuracy mean -> 99.49; mean of std loss -> 0.05503719489690131
+
+    # Jupyter Notebooks
+        - https://github.com/ekholabs/DLinK/blob/master/notebooks/keras
 
     # Examples
         The Advanced Activation function SineReLU have to be imported from the


### PR DESCRIPTION
Hi @fchollet and @ahundt,

I put some more time in the SineReLU and improved it, from a performance and running time perspective. The function is now simpler, faster and the results are better.

* Increase speed by reducing the computation: instead of using sigmoid and e, just use the difference of sin(Z) and cos(Z).
* Make the function differentiable

I wrote a Medium post about it, which will serve as inspiration for a paper to, hopefully, get out next year (which will be way more technical than the post).

Next to the documentation written in the code, I also took the time run it several times and get a more interesting comparison:

![image](https://user-images.githubusercontent.com/5129209/40930164-2b25aa68-6827-11e8-9ec3-db593c05af72.png)

Link for the Medium story: https://medium.com/@wilder.rodrigues/sinerelu-an-alternative-to-the-relu-activation-function-e46a6199997d

Thanks in advance.