### PR TITLE
the location of _obtain_input_shape changed

### DIFF
--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -67,7 +67,7 @@ from keras.regularizers import l2
 from keras.utils.layer_utils import convert_all_kernels_in_model
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.applications.imagenet_utils import decode_predictions
 from keras.applications.imagenet_utils import preprocess_input as _preprocess_input
 import keras.backend as K

--- a/keras_contrib/applications/nasnet.py
+++ b/keras_contrib/applications/nasnet.py
@@ -39,7 +39,7 @@ from keras.layers import add
 from keras.regularizers import l2
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.applications.inception_v3 import preprocess_input
 from keras.applications.imagenet_utils import decode_predictions
 from keras import backend as K

--- a/keras_contrib/applications/resnet.py
+++ b/keras_contrib/applications/resnet.py
@@ -34,8 +34,7 @@ from keras.layers.merge import add
 from keras.layers.normalization import BatchNormalization
 from keras.regularizers import l2
 from keras import backend as K
-from keras.applications.imagenet_utils import _obtain_input_shape
-
+from keras_applications.imagenet_utils import _obtain_input_shape
 
 def _bn_relu(x, bn_name=None, relu_name=None):
     """Helper to build a BN -> relu block

--- a/keras_contrib/applications/resnet.py
+++ b/keras_contrib/applications/resnet.py
@@ -36,6 +36,7 @@ from keras.regularizers import l2
 from keras import backend as K
 from keras_applications.imagenet_utils import _obtain_input_shape
 
+
 def _bn_relu(x, bn_name=None, relu_name=None):
     """Helper to build a BN -> relu block
     """

--- a/keras_contrib/applications/ror.py
+++ b/keras_contrib/applications/ror.py
@@ -21,7 +21,7 @@ from keras.layers.normalization import BatchNormalization
 from keras.utils.layer_utils import convert_all_kernels_in_model
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 import keras.backend as K
 
 TH_WEIGHTS_PATH = 'https://github.com/titu1994/Residual-of-Residual-Networks/releases/download/v0.2/ror_wrn_40_2_th_kernels_th_dim_ordering.h5'

--- a/keras_contrib/applications/wide_resnet.py
+++ b/keras_contrib/applications/wide_resnet.py
@@ -21,7 +21,7 @@ from keras.layers.normalization import BatchNormalization
 from keras.utils.layer_utils import convert_all_kernels_in_model
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 import keras.backend as K
 
 TH_WEIGHTS_PATH = 'https://github.com/titu1994/Wide-Residual-Networks/releases/download/v1.2/wrn_28_8_th_kernels_th_dim_ordering.h5'


### PR DESCRIPTION
When I tried to import 'densenet' from 'keras_contrib.applications', there is an import error saying that could not import '_obtain_input_shape' from 'keras.applications.imagenet_utils'. 

Then I found out it is in the location of 'keras_applications.imagenet_utils' and if I just change the 'from keras.applications.imagenet_utils import _obtain_input_shape' to 'from keras_applications.imagenet_utils import _obtain_input_shape', it would work.