### PR TITLE
Add dynamic input support for GroupNormalization

### DIFF
--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -499,49 +499,47 @@ class GroupNormalization(Layer):
 
     def call(self, inputs, **kwargs):
         input_shape = K.int_shape(inputs)
+        tensor_input_shape = K.shape(inputs)
+
         # Prepare broadcasting shape.
-        ndim = len(input_shape)
         reduction_axes = list(range(len(input_shape)))
         del reduction_axes[self.axis]
         broadcast_shape = [1] * len(input_shape)
-        broadcast_shape[self.axis] = input_shape[self.axis]
+        broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
+        broadcast_shape.insert(1, self.groups)
 
-        reshape_group_shape = list(input_shape)
-        reshape_group_shape[self.axis] = input_shape[self.axis] // self.groups
-        group_shape = [-1, self.groups]
-        group_shape.extend(reshape_group_shape[1:])
-        group_reduction_axes = list(range(len(group_shape)))
+        reshape_group_shape = K.shape(inputs)
+        group_axes = [reshape_group_shape[i] for i in range(len(input_shape))]
+        group_axes[self.axis] = input_shape[self.axis] // self.groups
+        group_axes.insert(1, self.groups)
 
-        # Determines whether broadcasting is needed.
-        needs_broadcasting = (sorted(reduction_axes) != list(range(ndim))[:-1])
-
+        # reshape inputs to new group shape
+        group_shape = [group_axes[0], self.groups] + group_axes[2:]
+        group_shape = K.stack(group_shape)
         inputs = K.reshape(inputs, group_shape)
+
+        group_reduction_axes = list(range(len(group_axes)))
+        group_reduction_axes = group_reduction_axes[2:]
 
         mean, variance = K.moments(inputs, group_reduction_axes[2:], keep_dims=True)
         inputs = (inputs - mean) / (K.sqrt(variance + self.epsilon))
 
-        original_shape = [-1] + list(input_shape[1:])
-        inputs = K.reshape(inputs, original_shape)
+        # prepare broadcast shape
+        inputs = K.reshape(inputs, group_shape)
 
-        if needs_broadcasting:
-            outputs = inputs
+        outputs = inputs
 
-            # In this case we must explicitly broadcast all parameters.
-            if self.scale:
-                broadcast_gamma = K.reshape(self.gamma, broadcast_shape)
-                outputs = outputs * broadcast_gamma
+        # In this case we must explicitly broadcast all parameters.
+        if self.scale:
+            broadcast_gamma = K.reshape(self.gamma, broadcast_shape)
+            outputs = outputs * broadcast_gamma
 
-            if self.center:
-                broadcast_beta = K.reshape(self.beta, broadcast_shape)
-                outputs = outputs + broadcast_beta
-        else:
-            outputs = inputs
+        if self.center:
+            broadcast_beta = K.reshape(self.beta, broadcast_shape)
+            outputs = outputs + broadcast_beta
 
-            if self.scale:
-                outputs = outputs * self.gamma
-
-            if self.center:
-                outputs = outputs + self.beta
+        # finally we reshape the output back to the input shape
+        outputs = K.reshape(outputs, tensor_input_shape)
 
         return outputs
 

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -519,8 +519,6 @@ class GroupNormalization(Layer):
         inputs = K.reshape(inputs, group_shape)
 
         group_reduction_axes = list(range(len(group_axes)))
-        group_reduction_axes = group_reduction_axes[2:]
-
         mean, variance = K.moments(inputs, group_reduction_axes[2:], keep_dims=True)
         inputs = (inputs - mean) / (K.sqrt(variance + self.epsilon))
 


### PR DESCRIPTION
Add `None` as input shape for all but the channel dimension in GroupNormalization.

Basically, now supports models built in this form : 

```python
from keras.layers import Input
from keras.models import Model
ip = Input(shape=(None, None, 4))
x = GroupNormalization(groups=2, axis=-1)(ip)
model = Model(ip, x)
model.summary()
```

will give an output summary of : 

```
_________________________________________________________________
Layer (type)                 Output Shape              Param #   
=================================================================
input_1 (InputLayer)         (None, None, None, 4)     0         
_________________________________________________________________
group_normalization_1 (Group (None, None, None, 4)     8         
=================================================================
Total params: 8
Trainable params: 8
Non-trainable params: 0
_________________________________________________________________
```