### PR TITLE
Fix: Can't import keras-contrib with keras2.2.1+ #291

### DIFF
--- a/keras_contrib/layers/convolutional.py
+++ b/keras_contrib/layers/convolutional.py
@@ -12,7 +12,7 @@ from keras.engine import InputSpec
 from keras.layers.convolutional import Convolution3D
 from keras.utils.generic_utils import get_custom_objects
 from keras.utils.conv_utils import conv_output_length
-from keras.utils.conv_utils import normalize_data_format
+from keras.backend.common import normalize_data_format
 import numpy as np
 
 


### PR DESCRIPTION
This PR is to fix #291 .

`normalize_data_format` function was moved to `keras.backend.common` from `keras.utils.conv_utils`  since keras 2.2.1 .
So, currently keras-contrib can't import with keras 2.2.1+ .

```
import keras_contrib  # ImportError !
```

This PR isn't thought compatibility.
(I believe that keras-contrib support only master branch of Keras.)
Also, Unit tests failed due to problems from before.

