### PR TITLE
Fix issue #291 - broken compatibility with Keras since 2.2.1 due to wrong import

### DIFF
--- a/keras_contrib/layers/convolutional.py
+++ b/keras_contrib/layers/convolutional.py
@@ -12,7 +12,6 @@ from keras.engine import InputSpec
 from keras.layers.convolutional import Convolution3D
 from keras.utils.generic_utils import get_custom_objects
 from keras.utils.conv_utils import conv_output_length
-from keras.utils.conv_utils import normalize_data_format
 import numpy as np
 
 
@@ -110,7 +109,7 @@ class CosineConvolution2D(Layer):
         self.activation = activations.get(activation)
         self.padding = padding
         self.strides = tuple(strides)
-        self.data_format = normalize_data_format(data_format)
+        self.data_format = K.normalize_data_format(data_format)
         self.kernel_regularizer = regularizers.get(kernel_regularizer)
         self.bias_regularizer = regularizers.get(bias_regularizer)
         self.activity_regularizer = regularizers.get(activity_regularizer)
@@ -297,7 +296,7 @@ class SubPixelUpscaling(Layer):
         super(SubPixelUpscaling, self).__init__(**kwargs)
 
         self.scale_factor = scale_factor
-        self.data_format = normalize_data_format(data_format)
+        self.data_format = K.normalize_data_format(data_format)
 
     def build(self, input_shape):
         pass


### PR DESCRIPTION
Although there is another PR with this fix, it seems that it contains test errors and I also observed that the import is not right, as it is not importing from the Keras backend, as seen here:

```
https://github.com/keras-team/keras/blob/d40656e5799dfd22e96b8bab217638b2934a6894/tests/keras/utils/conv_utils_test.py

K.normalize_data_format('channels_middle')
```

This has been tested on a Databricks cluster and is working.

![image](https://user-images.githubusercontent.com/5129209/43406538-b684c41a-941c-11e8-8f6e-5a00acd65020.png)
