### PR TITLE
Cyclic lr log

### DIFF
--- a/keras_contrib/callbacks/cyclical_learning_rate.py
+++ b/keras_contrib/callbacks/cyclical_learning_rate.py
@@ -59,6 +59,10 @@ class CyclicLR(Callback):
                                 scale_mode='cycle')
             model.fit(X_train, Y_train, callbacks=[clr])
         ```
+
+    # References
+
+      - [Cyclical Learning Rates for Training Neural Networks](https://arxiv.org/abs/1506.01186)
     """
 
     def __init__(

--- a/keras_contrib/callbacks/cyclical_learning_rate.py
+++ b/keras_contrib/callbacks/cyclical_learning_rate.py
@@ -148,3 +148,7 @@ class CyclicLR(Callback):
 
         for k, v in logs.items():
             self.history.setdefault(k, []).append(v)
+
+    def on_epoch_end(self, epoch, logs=None):
+        logs = logs or {}
+        logs['lr'] = K.get_value(self.model.optimizer.lr)


### PR DESCRIPTION
Add saving of the most recent learning rate to the log on_epoch end. While this won't capture the triangle if it is many times per epoch, the recommended schedules are one triangle every 2-8 epochs, in which case these values will give a good idea of how the learning rate changes over time.

@bckenstler