### PR TITLE
Spatial Tranformer Networks

### DIFF
--- a/keras_contrib/layers/__init__.py
+++ b/keras_contrib/layers/__init__.py
@@ -11,3 +11,4 @@ from .advanced_activations import *
 from .wrappers import *
 from .convolutional_recurrent import *
 from .crf import *
+from .spatial_transformer_networks import *

--- a/keras_contrib/layers/spatial_transformer_networks.py
+++ b/keras_contrib/layers/spatial_transformer_networks.py
@@ -1,0 +1,172 @@
+from .. import backend as K
+from keras.engine import Layer
+
+if K.backend() == 'tensorflow':
+    import tensorflow as tf
+    def K_arange(start, stop=None, step=1, dtype='int32'):
+        result = tf.range(start, limit=stop, delta=step, name='arange')
+        if dtype != 'int32':
+            result = tf.cast(result, dtype)
+        return result
+
+    def K_meshgrid(start1, end1, num1, start2, end2, num2):
+        return tf.meshgrid(tf.linspace(start1, end1, num1), tf.linspace(start2, end2, num2))
+
+    def K_matmul(x, y):
+        return tf.matmul(x, y)
+
+elif K.backend() == 'theano':
+    from theano import tensor as T
+    def K_arange(start, stop=None, step=1, dtype='int32'):
+        return T.arange(start, stop=stop, step=step, dtype=dtype)
+
+    def K_meshgrid(start1, end1, num1, start2, end2, num2):
+        step1 = ((end1 - start1) / num1)
+        step2 = ((end2 - start2) / num2)
+        return T.mgrid[start1:end1:step1, start2:end2:step2]
+
+    def K_matmul(x, y):
+        return T.dot(x, y)
+
+
+class SpatialTransformer(Layer):
+
+    def __init__(self, localisation_network, output_dim, **kwargs):
+        self.locnet = localisation_network
+        self.output_size = output_dim
+        super(SpatialTransformer, self).__init__(**kwargs)
+
+    def build(self, input_shape):
+        self.locnet.build(input_shape)
+        self.trainable_weights = self.locnet.trainable_weights
+
+    def compute_output_shape(self, input_shape):
+        output_size = self.output_size
+        return (None,
+                int(output_size[0]),
+                int(output_size[1]),
+                int(input_shape[-1]))
+
+    def call(self, X, mask=None):
+        affine_transformation = self.locnet.call(X)
+        output = self._transform(affine_transformation, X, self.output_size)
+        return output
+
+    def _repeat(self, x, num_repeats):
+        x = K.expand_dims(x, axis=-1)
+        x = K.repeat_elements(x, num_repeats, axis=1)
+        return K.reshape(x, [-1])
+
+    def _interpolate(self, image, x, y, output_size):
+        batch_size = K.shape(image)[0]
+        height = K.shape(image)[1]
+        width = K.shape(image)[2]
+        num_channels = K.shape(image)[3]
+
+        x = K.cast(x , dtype='float32')
+        y = K.cast(y , dtype='float32')
+
+        height_float = K.cast(height, dtype='float32')
+        width_float = K.cast(width, dtype='float32')
+
+        output_height = output_size[0]
+        output_width  = output_size[1]
+
+        x = .5 * (x + 1.0) * (width_float)
+        y = .5 * (y + 1.0) * (height_float)
+
+        x0 = K.cast(x, 'int32')
+        x1 = x0 + 1
+        y0 = K.cast(y, 'int32')
+        y1 = y0 + 1
+
+        max_x = int(K.int_shape(image)[1] - 1)
+        max_y = int(K.int_shape(image)[2] - 1)
+        x0 = K.clip(x0, 0, max_x)
+        x1 = K.clip(x1, 0, max_x)
+        y0 = K.clip(y0, 0, max_y)
+        y1 = K.clip(y1, 0, max_y)
+
+        flat_image_dimensions = width*height
+        pixels_batch = K_arange(batch_size)*flat_image_dimensions
+        flat_output_dimensions = output_height*output_width
+        base = self._repeat(pixels_batch, flat_output_dimensions)
+        base_y0 = base + y0*width
+        base_y1 = base + y1*width
+        indices_a = base_y0 + x0
+        indices_b = base_y1 + x0
+        indices_c = base_y0 + x1
+        indices_d = base_y1 + x1
+
+        flat_image = K.reshape(image, shape=(-1, num_channels))
+        flat_image = K.cast(flat_image, dtype='float32')
+        pixel_values_a = K.gather(flat_image, indices_a)
+        pixel_values_b = K.gather(flat_image, indices_b)
+        pixel_values_c = K.gather(flat_image, indices_c)
+        pixel_values_d = K.gather(flat_image, indices_d)
+
+        x0 = K.cast(x0, 'float32')
+        x1 = K.cast(x1, 'float32')
+        y0 = K.cast(y0, 'float32')
+        y1 = K.cast(y1, 'float32')
+
+        area_a = K.expand_dims(((x1 - x) * (y1 - y)), 1)
+        area_b = K.expand_dims(((x1 - x) * (y - y0)), 1)
+        area_c = K.expand_dims(((x - x0) * (y1 - y)), 1)
+        area_d = K.expand_dims(((x - x0) * (y - y0)), 1)
+
+        values_a = area_a * pixel_values_a
+        values_b = area_b * pixel_values_b
+        values_c = area_c * pixel_values_c
+        values_d = area_d * pixel_values_d
+        output = values_a + values_b + values_c + values_d
+
+        return output
+
+    def _meshgrid(self, height, width):
+        x_coordinates, y_coordinates = K_meshgrid(-1., 1., width, -1., 1., height)
+        x_coordinates = K.reshape(x_coordinates, [-1])
+        y_coordinates = K.reshape(y_coordinates, [-1])
+        ones = K.ones_like(x_coordinates)
+        indices_grid = K.concatenate([x_coordinates, y_coordinates, ones], 0)
+        return indices_grid
+
+    def _transform(self, affine_transformation, input_shape, output_size):
+        batch_size = K.shape(input_shape)[0]
+        height = K.shape(input_shape)[1]
+        width = K.shape(input_shape)[2]
+        num_channels = K.shape(input_shape)[3]
+
+        affine_transformation = K.reshape(affine_transformation,
+                                        shape=(batch_size, 2, 3))
+
+        affine_transformation = K.cast(affine_transformation, 'float32')
+
+        width = K.cast(width, dtype='float32')
+        height = K.cast(height, dtype='float32')
+        output_height = output_size[0]
+        output_width = output_size[1]
+        indices_grid = self._meshgrid(output_height, output_width)
+        indices_grid = K.expand_dims(indices_grid, 0)
+        indices_grid = K.reshape(indices_grid, [-1])
+
+        indices_grid = K.tile(indices_grid, K.stack([batch_size]))
+        indices_grid = K.reshape(indices_grid, (batch_size, 3, -1))
+
+        transformed_grid = K_matmul(affine_transformation, indices_grid)
+
+        x_s = transformed_grid[0:, 0:1, 0:]
+        y_s = transformed_grid[0:, 1:, 0:]
+        x_s_flatten = K.reshape(x_s, [-1])
+        y_s_flatten = K.reshape(y_s, [-1])
+
+        transformed_image = self._interpolate(input_shape,
+                                              x_s_flatten,
+                                              y_s_flatten,
+                                              output_size)
+
+        transformed_image = K.reshape(transformed_image, shape=(batch_size,
+                                                                output_height,
+                                                                output_width,
+                                                                num_channels))
+        return transformed_image

--- a/keras_contrib/layers/spatial_transformer_networks.py
+++ b/keras_contrib/layers/spatial_transformer_networks.py
@@ -115,6 +115,14 @@ class SpatialTransformer(Layer):
         return K.reshape(x, [-1])
 
     def _interpolate(self, image, x, y, output_size):
+        """
+        Performs bilinear interpolation of the input images according to
+        the normalized coordinates provided by the sampling grid. This is
+        done to interpolate the remaining pixels of the transformed image
+        which could not be assigned a value during transformation.
+
+        Reference - https://en.wikipedia.org/wiki/Bilinear_interpolation
+        """
         batch_size = K.shape(image)[0]
         height = K.shape(image)[1]
         width = K.shape(image)[2]
@@ -190,6 +198,13 @@ class SpatialTransformer(Layer):
         return indices_grid
 
     def _transform(self, affine_transformation, input_shape, output_size):
+        """
+        Given a 6 parameter affine transformation matrix, this function
+        actually performs the transformation (warping) of the original
+        localised image.
+
+        Reference- http://www.imageprocessingbasics.com/geometric-transforms
+        """
         batch_size = K.shape(input_shape)[0]
         height = K.shape(input_shape)[1]
         width = K.shape(input_shape)[2]

--- a/keras_contrib/layers/spatial_transformer_networks.py
+++ b/keras_contrib/layers/spatial_transformer_networks.py
@@ -3,6 +3,7 @@ from keras.engine import Layer
 
 if K.backend() == 'tensorflow':
     import tensorflow as tf
+
     def K_arange(start, stop=None, step=1, dtype='int32'):
         result = tf.range(start, limit=stop, delta=step, name='arange')
         if dtype != 'int32':
@@ -10,13 +11,15 @@ if K.backend() == 'tensorflow':
         return result
 
     def K_meshgrid(start1, end1, num1, start2, end2, num2):
-        return tf.meshgrid(tf.linspace(start1, end1, num1), tf.linspace(start2, end2, num2))
+        return tf.meshgrid(tf.linspace(start1, end1, num1),
+                           tf.linspace(start2, end2, num2))
 
     def K_matmul(x, y):
         return tf.matmul(x, y)
 
 elif K.backend() == 'theano':
     from theano import tensor as T
+
     def K_arange(start, stop=None, step=1, dtype='int32'):
         return T.arange(start, stop=stop, step=step, dtype=dtype)
 
@@ -63,14 +66,14 @@ class SpatialTransformer(Layer):
         width = K.shape(image)[2]
         num_channels = K.shape(image)[3]
 
-        x = K.cast(x , dtype='float32')
-        y = K.cast(y , dtype='float32')
+        x = K.cast(x, dtype='float32')
+        y = K.cast(y, dtype='float32')
 
         height_float = K.cast(height, dtype='float32')
         width_float = K.cast(width, dtype='float32')
 
         output_height = output_size[0]
-        output_width  = output_size[1]
+        output_width = output_size[1]
 
         x = .5 * (x + 1.0) * (width_float)
         y = .5 * (y + 1.0) * (height_float)
@@ -87,12 +90,12 @@ class SpatialTransformer(Layer):
         y0 = K.clip(y0, 0, max_y)
         y1 = K.clip(y1, 0, max_y)
 
-        flat_image_dimensions = width*height
-        pixels_batch = K_arange(batch_size)*flat_image_dimensions
-        flat_output_dimensions = output_height*output_width
+        flat_image_dimensions = width * height
+        pixels_batch = K_arange(batch_size) * flat_image_dimensions
+        flat_output_dimensions = output_height * output_width
         base = self._repeat(pixels_batch, flat_output_dimensions)
-        base_y0 = base + y0*width
-        base_y1 = base + y1*width
+        base_y0 = base + y0 * width
+        base_y1 = base + y1 * width
         indices_a = base_y0 + x0
         indices_b = base_y1 + x0
         indices_c = base_y0 + x1
@@ -124,7 +127,8 @@ class SpatialTransformer(Layer):
         return output
 
     def _meshgrid(self, height, width):
-        x_coordinates, y_coordinates = K_meshgrid(-1., 1., width, -1., 1., height)
+        x_coordinates, y_coordinates = K_meshgrid(-1., 1., width,
+                                                  -1., 1., height)
         x_coordinates = K.reshape(x_coordinates, [-1])
         y_coordinates = K.reshape(y_coordinates, [-1])
         ones = K.ones_like(x_coordinates)
@@ -138,7 +142,7 @@ class SpatialTransformer(Layer):
         num_channels = K.shape(input_shape)[3]
 
         affine_transformation = K.reshape(affine_transformation,
-                                        shape=(batch_size, 2, 3))
+                                          shape=(batch_size, 2, 3))
 
         affine_transformation = K.cast(affine_transformation, 'float32')
 

--- a/tests/keras_contrib/layers/test_spatial_transformer_network.py
+++ b/tests/keras_contrib/layers/test_spatial_transformer_network.py
@@ -1,0 +1,65 @@
+import pytest
+import numpy as np
+
+from numpy.testing import assert_allclose
+
+from keras_contrib.utils.test_utils import keras_test
+from keras import backend as K
+from keras_contrib import backend as KC
+from keras_contrib.layers import SpatialTransformer
+from keras.models import Sequential
+from keras.layers import MaxPooling2D, Conv2D, Flatten, Dense, Activation
+np.random.seed(1)
+
+
+@keras_test
+def test_spatial_transformer_network():
+    x_train = np.ones((1, 60, 60, 1))
+
+    b = np.zeros((2, 3))
+    b[0, 0] = 1
+    b[1, 1] = 1
+    b = b.flatten()
+
+    W = np.zeros((50, 6))
+    weights = [W, b]
+
+    localisation_network = Sequential()
+
+    localisation_network.add(MaxPooling2D(pool_size=(2, 2), input_shape=x_train.shape[1:]))
+    localisation_network.add(Conv2D(20, (5, 5)))
+    localisation_network.add(Flatten())
+    localisation_network.add(Dense(50))
+    localisation_network.add(Activation('relu'))
+    localisation_network.add(Dense(6, weights=weights))
+
+    model = Sequential()
+
+    model.add(SpatialTransformer(localisation_network=localisation_network,
+                                 output_dim=(30, 30), input_shape=x_train.shape[1:]))
+
+    model.add(Conv2D(32, (3, 3), padding='same'))
+    model.add(Activation('relu'))
+    model.add(MaxPooling2D(pool_size=(2, 2)))
+
+    model.add(Conv2D(32, (3, 3), padding='same'))
+    model.add(Activation('relu'))
+    model.add(MaxPooling2D(pool_size=(2, 2)))
+
+    model.add(Flatten())
+
+    model.add(Dense(256))
+    model.add(Activation('relu'))
+
+    model.add(Dense(10))
+    model.add(Activation('softmax'))
+
+    model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['acc'])
+    out = model.predict(np.ones_like(x_train))
+
+    assert_allclose(out, np.array([[0.11505639, 0.11439, 0.10204504, 0.09712951, 0.09869344,
+                                    0.06929098, 0.07713472, 0.08842108, 0.11671967, 0.12111916]]))
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
This is the implementation of [spatial transformer networks by the good people at DeepMind](https://arxiv.org/abs/1506.02025).

Quoting their abstract -  
> the use of spatial transformers results in models which learn invariance to translation, scale, rotation and more generic warping, resulting in state-of-the-art performance on several benchmarks, and for a number of classes of transformations.

I wanted to use STN for my research oriented tasks it would be a easier for me if I could directly import this layer from keras_contrib so that I could use it across my machines.

I have not updated the docs or written tests as it seems like the build is already failing. I will write tests once the master build is passed. I have tested the code locally on distorted mnist dataset. Perfect results.

fix #107 

EDIT: [Code credits](https://github.com/oarriaga/STN.keras/blob/master/src/models/layers.py) goes to @oarriaga 