### PR TITLE
Update convolutional.py

### DIFF
--- a/keras_contrib/layers/convolutional.py
+++ b/keras_contrib/layers/convolutional.py
@@ -12,7 +12,7 @@ from keras.engine import InputSpec
 from keras.layers.convolutional import Convolution3D
 from keras.utils.generic_utils import get_custom_objects
 from keras.utils.conv_utils import conv_output_length
-from keras.backend.common import normalize_data_format
+from keras.utils.conv_utils import normalize_data_format
 import numpy as np
 
 


### PR DESCRIPTION
fix the following problem.


from keras.backend.common import normalize_data_formatImportError: cannot import name 'normalize_data_format'