### PR TITLE
Add functional layer tools

### DIFF
--- a/keras_contrib/layers/__init__.py
+++ b/keras_contrib/layers/__init__.py
@@ -11,3 +11,4 @@ from .advanced_activations import *
 from .wrappers import *
 from .convolutional_recurrent import *
 from .crf import *
+from .functional import *

--- a/keras_contrib/layers/functional.py
+++ b/keras_contrib/layers/functional.py
@@ -1,0 +1,88 @@
+"""Functional tools for working with layers."""
+
+from functools import reduce
+
+__all__ = ['sequence', 'repeat']
+
+
+def sequence(*layers):
+    """Composes layers sequentially.
+
+    # Arguments
+        *layers: Layers, or other callables that map a tensor to a tensor.
+
+    # Returns
+        A callable that maps a tensor to the output tensor of the last layer.
+
+    # Examples
+
+    ```python
+        from keras.layers import Dense, Input
+        from keras.models import Model
+        from keras_contrib.layers import sequence
+
+        input_layer = Input(shape=(16,))
+
+        output = sequence(
+            Dense(8, activation='relu'),
+            Dense(8, activation='relu'),
+            Dense(8, activation='relu'),
+            Dense(1),
+        )(input_layer)
+
+        model = Model(input_layer, output)
+    ```
+    """
+    return reduce(lambda f, g: lambda x: g(f(x)), layers, lambda x: x)
+
+
+def repeat(n, layer_factory):
+    """Constructs a sequence of repeated layers.
+
+    # Arguments
+        n: int. The number of times to repeat the layer.
+        layer_factory: A function taking no arguments that returns a layer or
+            another callable that maps a tensor to a tensor.
+
+    # Returns
+        A callable that maps a tensor to the output tensor of the last layer.
+
+    # Examples
+
+    ```python
+        from keras.layers import Dense, Input
+        from keras.models import Model
+        from keras_contrib.layers import repeat, sequence
+
+        input_layer = Input(shape=(16,))
+
+        output = sequence(
+            repeat(3, lambda: Dense(8, activation='relu')),
+            Dense(1),
+        )(input_layer)
+
+        model = Model(input_layer, output)
+    ```
+
+    `sequence` and `repeat` can be freely intermixed with layers, since they
+    both map a tensor to a tensor:
+
+    ```python
+        from keras.layers import Activation, Dense, Input
+        from keras.models import Model
+        from keras_contrib.layers import repeat, sequence
+
+        input_layer = Input(shape=(16,))
+
+        output = sequence(
+            repeat(3, lambda: sequence(
+                Dense(8),
+                Activation('relu'),
+            )),
+            Dense(1),
+        )(input_layer)
+
+        model = Model(input_layer, output)
+    ```
+    """
+    return sequence(*(layer_factory() for _ in range(n)))

--- a/tests/keras_contrib/layers/functional_test.py
+++ b/tests/keras_contrib/layers/functional_test.py
@@ -1,0 +1,35 @@
+"""Tests for functions in keras_contrib/layers/functional.py."""
+
+import pytest
+
+from keras.layers import Dense, Input
+from keras.models import Model
+from keras_contrib.layers import repeat, sequence
+
+
+def test_sequence():
+    input_layer = Input(shape=(16,))
+    output = sequence(
+        Dense(8),
+        Dense(1),
+    )(input_layer)
+    model = Model(input_layer, output)
+    assert len(model.layers) == 3
+    assert model.layers[1].__class__.__name__ == 'Dense'
+    assert model.layers[2].__class__.__name__ == 'Dense'
+    assert model.layers[1].get_output_shape_at(0) == (None, 8)
+    assert model.layers[2].get_output_shape_at(0) == (None, 1)
+
+
+def test_repeat():
+    input_layer = Input(shape=(16,))
+    output = repeat(2, lambda: Dense(8))(input_layer)
+    model = Model(input_layer, output)
+    assert len(model.layers) == 3
+    assert model.layers[1].__class__.__name__ == 'Dense'
+    assert model.layers[2].__class__.__name__ == 'Dense'
+    assert id(model.layers[1]) != id(model.layers[2])
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Adds two functional tools for working with layers, `sequence` and `repeat`. They are simple composable functions that allow you to write cleaner code when using the Functional API. Instead of ugly code like:

```python
input_layer = Input(shape=(16,))
x = Dense(8, activation='relu')(input_layer)
x = Dense(8, activation='relu')(x)
x = Dense(8, activation='relu')(x)
x = Dense(1)(x)
model = Model(input_layer, x)
```

applying the current layer to the previous layer manually on each line, `sequence` allows you to write:

```python
input_layer = Input(shape=(16,))
output = sequence(
    Dense(8, activation='relu'),
    Dense(8, activation='relu'),
    Dense(8, activation='relu'),
    Dense(1),
)(input_layer)
model = Model(input_layer, output)
```

`sequence` takes any number of callables mapping a tensor to a tensor and returns a callable mapping a tensor to a tensor. So you can logically nest `sequence` calls, as in this example:

```python
def residual_block(units):
    return lambda a: sequence(
        Activation('relu'),
        Dense(units),
        Activation('relu'),
        Dense(units),
        lambda b: Add()([a, b]),
    )(a)

output = sequence(
    residual_block(16),
    residual_block(16),
    Dense(1),
)(input_layer)
```

`repeat`, which takes a repeat count and a layer factory function, can be used to simplify creation of a deep model, as follows:

```python
output = sequence(
    repeat(4, lambda: residual_block(16)),
    Dense(8),
    repeat(4, lambda: residual_block(8)),
    Dense(1),
)(input_layer)
```

As you can see, these functions allow you to easily create deep models without repetitive code.