### PR TITLE
Removing the clip functions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - travis_retry pip install --only-binary=numpy,scipy,pandas numpy nose scipy h5py theano pytest pytest-pep8 pandas --progress-bar off
-  - pip install https://github.com/keras-team/keras.git --progress-bar off
+  - pip install git+https://github.com/keras-team/keras.git --progress-bar off
 
   # set library path
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - travis_retry pip install --only-binary=numpy,scipy,pandas numpy nose scipy h5py theano pytest pytest-pep8 pandas --progress-bar off
-  - pip install keras==2.2.4 --progress-bar off
+  - pip install https://github.com/keras-team/keras.git --progress-bar off
 
   # set library path
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH

--- a/keras_contrib/backend/cntk_backend.py
+++ b/keras_contrib/backend/cntk_backend.py
@@ -4,29 +4,6 @@ import cntk as C
 import numpy as np
 
 
-def clip(x, min_value, max_value):
-    """Element-wise value clipping.
-
-    If min_value > max_value, clipping range is [min_value,min_value].
-
-    # Arguments
-        x: Tensor or variable.
-        min_value: Tensor, float, int, or None.
-            If min_value is None, defaults to -infinity.
-        max_value: Tensor, float, int, or None.
-            If max_value is None, defaults to infinity.
-
-    # Returns
-        A tensor.
-    """
-    if max_value is None:
-        max_value = np.inf
-    if min_value is None:
-        min_value = -np.inf
-    max_value = C.maximum(min_value, max_value)
-    return C.clip(x, min_value, max_value)
-
-
 def moments(x, axes, shift=None, keep_dims=False):
     ''' Calculates and returns the mean and variance of the input '''
     mean, variant = KCN._moments(x, axes=axes, shift=shift, keep_dims=keep_dims)

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -163,28 +163,3 @@ def moments(x, axes, shift=None, keep_dims=False):
     ''' Wrapper over tensorflow backend call '''
 
     return tf.nn.moments(x, axes, shift=shift, keep_dims=keep_dims)
-
-
-def clip(x, min_value, max_value):
-    """Element-wise value clipping.
-
-    If min_value > max_value, clipping range is [min_value,min_value].
-
-    # Arguments
-        x: Tensor or variable.
-        min_value: Tensor, float, int, or None.
-            If min_value is None, defaults to -infinity.
-        max_value: Tensor, float, int, or None.
-            If max_value is None, defaults to infinity.
-
-    # Returns
-        A tensor.
-    """
-    if max_value is None:
-        max_value = np.inf
-    if min_value is None:
-        min_value = -np.inf
-    min_value = _to_tensor(min_value, x.dtype.base_dtype)
-    max_value = _to_tensor(max_value, x.dtype.base_dtype)
-    max_value = tf.maximum(min_value, max_value)
-    return tf.clip_by_value(x, min_value, max_value)

--- a/keras_contrib/backend/theano_backend.py
+++ b/keras_contrib/backend/theano_backend.py
@@ -148,26 +148,3 @@ def moments(x, axes, shift=None, keep_dims=False):
     var_batch = KTH.var(x, axis=axes, keepdims=keep_dims)
 
     return mean_batch, var_batch
-
-
-def clip(x, min_value, max_value):
-    """Element-wise value clipping.
-
-    If min_value > max_value, clipping range is [min_value,min_value].
-
-    # Arguments
-        x: Tensor or variable.
-        min_value: Tensor, float, int, or None.
-            If min_value is None, defaults to -infinity.
-        max_value: Tensor, float, int, or None.
-            If max_value is None, defaults to infinity.
-
-    # Returns
-        A tensor.
-    """
-    if max_value is None:
-        max_value = np.inf
-    if min_value is None:
-        min_value = -np.inf
-    max_value = T.maximum(min_value, max_value)
-    return T.clip(x, min_value, max_value)

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -2,7 +2,6 @@ from keras.engine import Layer, InputSpec
 from .. import initializers, regularizers, constraints
 from .. import backend as K
 from keras.utils.generic_utils import get_custom_objects
-
 import numpy as np
 
 

--- a/tests/keras_contrib/backend/backend_test.py
+++ b/tests/keras_contrib/backend/backend_test.py
@@ -169,43 +169,6 @@ class TestBackend(object):
                     assert_allclose(th_mean_val, cntk_mean_val, rtol=1e-4, atol=1e-10)
                     assert_allclose(th_var_val, cntk_var_val, rtol=1e-4, atol=1e-10)
 
-    def test_clip(self):
-        check_single_tensor_operation('clip', (4, 2), min_value=0.4, max_value=0.6)
-        check_single_tensor_operation('clip', (4, 2), min_value=0.4, max_value=None)
-
-        cases = [
-            # (x, min_value, max_value, expected)
-            (1, 0, 2, 1),
-            (1, 2, 0, 2),
-            (-1, 0, 2, 0),
-            (-1, 2, 0, 2),
-            (3, 0, 2, 2),
-            (3, 2, 0, 2),
-            (1, 0, np.inf, 1),
-            (1, np.inf, 0, np.inf),
-            (1, 0, -np.inf, 0),
-            (1, -np.inf, 0, 0),
-            (-1, 0, -np.inf, 0),
-            (-1, -np.inf, 0, -1),
-            (1, 0, None, 1),
-            (-1, 0, None, 0),
-
-            # NOTE: In the following two cases, Keras 2.0.8 raises an
-            # error on all backends, but this is a sensible extension.
-            (1, None, 0, 0),
-            (-1, None, 0, -1),
-
-            # NOTE: In the following case, Keras 2.0.8 rasies an error
-            # for TensorFlow and Theano, but returns 0 for CNTK. This
-            # extends the TensorFlow and Theano backends to match the
-            # CNTK behavior instead of raising an error.
-            (0, None, None, 0),
-        ]
-        for K_, KC_ in [(KTF, KCTF), (KTH, KCTH)]:
-            for x, min_value, max_value, expected in cases:
-                actual = K_.eval(KC_.clip(K_.constant(x), min_value, max_value))
-                assert_allclose(expected, actual, atol=1e-5)
-
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
They are already in keras-team/keras. This shouldn't break anything because the user code will fallback automatically on the clip from the keras backend.