### PR TITLE
a negligence of the viterbi algorithm

### DIFF
--- a/keras_contrib/utils/save_load_utils.py
+++ b/keras_contrib/utils/save_load_utils.py
@@ -28,10 +28,7 @@ def save_all_weights(model, filepath, include_optimizer=True):
 
     with h5py.File(filepath, 'w') as f:
         model_weights_group = f.create_group('model_weights')
-        if legacy_models.needs_legacy_support(model):
-            model_layers = legacy_models.legacy_sequential_layers(model)
-        else:
-            model_layers = model.layers
+        model_layers = model.layers
         saving.save_weights_to_hdf5_group(model_weights_group, model_layers)
 
         if include_optimizer and hasattr(model, 'optimizer') and model.optimizer:


### PR DESCRIPTION
I write my own viterbi algorithm myself, using the same weights trained from the CRF model, I found that the final results from the model.predict and my own viterbi algorithm are sometimes different slightly. Below are my viterbi algorith.

rith.
import numpy as np
class CRF:
def init(self, kernel, chain_kernel, bias, left_boundary, right_boundary):
self.bias = bias
self.chain_kernel = chain_kernel
self.kernel = kernel
self.left_boundary = left_boundary
self.right_boundary = right_boundary
self.activation = linear
def viterbi_one_hot(self, X):
    return np.eye(len(self.bias), dtype=int)[self.viterbi_decoding(X)]

def viterbi_decoding(self, X):
    input_energy = self.activation(np.matmul(X, self.kernel) + self.bias)
    input_energy[0] += self.left_boundary
    input_energy[-1] += self.right_boundary
    min_energy = np.zeros_like(input_energy[0])
    argmin_tables = np.zeros(input_energy.shape, int)
    for t in range(len(input_energy)):
        energy = self.chain_kernel + np.expand_dims(input_energy[t] + min_energy, 1)
        argmin_tables[t] = np.argmin(energy, 0)
        min_energy = np.min(energy, 0)

    best_idx = np.argmin(min_energy)
best_idx = argmin_tables[-1, 0] # this is what the keras.contrib is doing!!!
    best_paths = np.zeros((len(argmin_tables),), int)
    for i in range(-1, -len(argmin_tables) - 1, -1):
        best_idx = argmin_tables[i][best_idx]
        best_paths[i] = best_idx

    return best_paths



below are my suggested changes for keras contrib:


    def recursion(self, input_energy, mask=None, go_backwards=False, return_sequences=True, return_logZ=True, input_length=None):
        """Forward (alpha) or backward (beta) recursion

        If `return_logZ = True`, compute the logZ, the normalization constant:

        \[ Z = \sum_{y1, y2, y3} exp(-E) # energy
          = \sum_{y1, y2, y3} exp(-(u1' y1 + y1' W y2 + u2' y2 + y2' W y3 + u3' y3))
          = sum_{y2, y3} (exp(-(u2' y2 + y2' W y3 + u3' y3)) sum_{y1} exp(-(u1' y1' + y1' W y2))) \]

        Denote:
            \[ S(y2) := sum_{y1} exp(-(u1' y1 + y1' W y2)), \]
            \[ Z = sum_{y2, y3} exp(log S(y2) - (u2' y2 + y2' W y3 + u3' y3)) \]
            \[ logS(y2) = log S(y2) = log_sum_exp(-(u1' y1' + y1' W y2)) \]
        Note that:
              yi's are one-hot vectors
              u1, u3: boundary energies have been merged

        If `return_logZ = False`, compute the Viterbi's best path lookup table.
        """
        chain_energy = self.chain_kernel
        chain_energy = K.expand_dims(chain_energy, 0)  # shape=(1, F, F): F=num of output features. 1st F is for t-1, 2nd F for t
        prev_target_val = K.zeros_like(input_energy[:, 0, :])  # shape=(B, F), dtype=float32

        if go_backwards:
            input_energy = K.reverse(input_energy, 1)
            if mask is not None:
                mask = K.reverse(mask, 1)

        initial_states = [prev_target_val, K.zeros_like(prev_target_val[:, :1])]
        constants = [chain_energy]

        if mask is not None:
            mask2 = K.cast(K.concatenate([mask, K.zeros_like(mask[:, :1])], axis=1), K.floatx())
            constants.append(mask2)

        def _step(input_energy_i, states):
            return self.step(input_energy_i, states, return_logZ)

        target_val_last, target_val_seq, state_last = K.rnn(_step, input_energy, initial_states, constants=constants,
                                                   input_length=input_length, unroll=self.unroll)

        if not return_logZ:
            argmin_table_last = K.cast(K.argmin(state_last[0], 1), 'int32')
            return target_val_seq, argmin_table_last 
        if return_sequences:
            if go_backwards:
                target_val_seq = K.reverse(target_val_seq, 1)
            return target_val_seq
        else:
            return target_val_last

    def viterbi_decoding(self, X, mask=None):
        input_energy = self.activation(K.dot(X, self.kernel) + self.bias)
        if self.use_boundary:
            input_energy = self.add_boundary_energy(input_energy, mask, self.left_boundary, self.right_boundary)

        argmin_tables, argmin_table_last = self.recursion(input_energy, mask, return_logZ=False)
        argmin_tables = K.cast(argmin_tables, 'int32')

        # backward to find best path, `initial_best_idx` can be selected from the last argmin_table
        argmin_tables = K.reverse(argmin_tables, 1)
        initial_best_idx = [K.expand_dims(argmin_table_last)]  # matrix instead of vector is required by tf `K.rnn`
#         initial_best_idx = [K.expand_dims(argmin_tables[:, 0, 0])]  # matrix instead of vector is required by tf `K.rnn`
        if K.backend() == 'theano':
            initial_best_idx = [K.T.unbroadcast(initial_best_idx[0], 1)]

        def gather_each_row(params, indices):
            n = K.shape(indices)[0]
            if K.backend() == 'theano':
                return params[K.T.arange(n), indices]
            else:
                indices = K.transpose(K.stack([K.tf.range(n), indices]))
                return K.tf.gather_nd(params, indices)

        def find_path(argmin_table, best_idx):
            next_best_idx = gather_each_row(argmin_table, best_idx[0][:, 0])
            next_best_idx = K.expand_dims(next_best_idx)
            if K.backend() == 'theano':
                next_best_idx = K.T.unbroadcast(next_best_idx, 1)
            return next_best_idx, [next_best_idx]

        _, best_paths, _ = K.rnn(find_path, argmin_tables, initial_best_idx, input_length=K.int_shape(X)[1], unroll=self.unroll)
        best_paths = K.reverse(best_paths, 1)
        best_paths = K.squeeze(best_paths, 2)

        return K.tf.one_hot(best_paths, self.units, dtype=K.floatx())

