### PR TITLE
Changed the imports to avoid depending on private functions.

### DIFF
--- a/keras_contrib/layers/convolutional.py
+++ b/keras_contrib/layers/convolutional.py
@@ -11,7 +11,7 @@ from keras import constraints
 from keras.layers import Layer
 from keras.layers import InputSpec
 from keras.utils import get_custom_objects
-from keras.utils.conv_utils import conv_output_length
+from keras_contrib.utils.conv_utils import conv_output_length
 from keras.backend.common import normalize_data_format
 import numpy as np
 

--- a/keras_contrib/layers/local.py
+++ b/keras_contrib/layers/local.py
@@ -8,4 +8,4 @@ from .. import regularizers
 from .. import constraints
 from keras.layers import Layer
 from keras.layers import InputSpec
-from keras.utils.conv_utils import conv_output_length
+from keras_contrib.utils.conv_utils import conv_output_length

--- a/keras_contrib/layers/pooling.py
+++ b/keras_contrib/layers/pooling.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 from .. import backend as K
 from keras.layers import Layer
 from keras.layers import InputSpec
-from keras.utils.conv_utils import conv_output_length
+from keras_contrib.utils.conv_utils import conv_output_length

--- a/keras_contrib/tests/advanced_activations_test.py
+++ b/keras_contrib/tests/advanced_activations_test.py
@@ -1,5 +1,5 @@
 import pytest
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from keras import layers
 
 

--- a/keras_contrib/utils/conv_utils.py
+++ b/keras_contrib/utils/conv_utils.py
@@ -1,0 +1,30 @@
+def conv_output_length(input_length, filter_size,
+                       padding, stride, dilation=1):
+    """Determines output length of a convolution given input length.
+
+    Copy of the function of keras-team/keras because it's not in the public API
+    So we can't use the function in keras-team/keras to test tf.keras
+
+    # Arguments
+        input_length: integer.
+        filter_size: integer.
+        padding: one of `"same"`, `"valid"`, `"full"`.
+        stride: integer.
+        dilation: dilation rate, integer.
+
+    # Returns
+        The output length (integer).
+    """
+    if input_length is None:
+        return None
+    assert padding in {'same', 'valid', 'full', 'causal'}
+    dilated_filter_size = filter_size + (filter_size - 1) * (dilation - 1)
+    if padding == 'same':
+        output_length = input_length
+    elif padding == 'valid':
+        output_length = input_length - dilated_filter_size + 1
+    elif padding == 'causal':
+        output_length = input_length
+    elif padding == 'full':
+        output_length = input_length + dilated_filter_size - 1
+    return (output_length + stride - 1) // stride

--- a/keras_contrib/utils/test_utils.py
+++ b/keras_contrib/utils/test_utils.py
@@ -1,10 +1,10 @@
 """Utilities related to Keras unit tests."""
+import sys
 import numpy as np
 from numpy.testing import assert_allclose
 import inspect
 
 from keras.engine import Model, Input
-from keras.models import Sequential
 from keras import backend as K
 
 
@@ -38,9 +38,12 @@ def get_test_data(num_train=1000, num_test=500, input_shape=(10,),
 
 def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
                input_data=None, expected_output=None,
-               expected_output_dtype=None, fixed_batch_size=False, tolerance=1e-3):
+               expected_output_dtype=None, fixed_batch_size=False):
     """Test routine for a layer with a single input tensor
     and single output tensor.
+
+    Copy of the function in keras-team/keras because it's not in the public API.
+    If we use the one from keras-team/keras it won't work with tf.keras.
     """
     # generate input data
     if input_data is None:
@@ -68,10 +71,7 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
     weights = layer.get_weights()
     layer.set_weights(weights)
 
-    # test and instantiation from weights
-    if 'weights' in inspect.getargspec(layer_cls.__init__):
-        kwargs['weights'] = weights
-        layer = layer_cls(**kwargs)
+    expected_output_shape = layer.compute_output_shape(input_shape)
 
     # test in functional API
     if fixed_batch_size:
@@ -81,63 +81,83 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
     y = layer(x)
     assert K.dtype(y) == expected_output_dtype
 
-    # check shape inference
+    # check with the functional API
     model = Model(x, y)
-    expected_output_shape = layer.compute_output_shape(input_shape)
+
     actual_output = model.predict(input_data)
     actual_output_shape = actual_output.shape
     for expected_dim, actual_dim in zip(expected_output_shape,
                                         actual_output_shape):
         if expected_dim is not None:
             assert expected_dim == actual_dim
+
     if expected_output is not None:
-        if tolerance is not None:
-            assert_allclose(actual_output, expected_output, rtol=tolerance)
+        assert_allclose(actual_output, expected_output, rtol=1e-3)
 
     # test serialization, weight setting at model level
     model_config = model.get_config()
-    recovered_model = Model.from_config(model_config)
+    recovered_model = model.__class__.from_config(model_config)
     if model.weights:
         weights = model.get_weights()
         recovered_model.set_weights(weights)
         _output = recovered_model.predict(input_data)
-        if tolerance is not None:
-            assert_allclose(_output, actual_output, rtol=tolerance)
+        assert_allclose(_output, actual_output, rtol=1e-3)
 
-    # test training mode (e.g. useful for dropout tests)
-    model.compile('rmsprop', 'mse')
-    model.train_on_batch(input_data, actual_output)
+    # test training mode (e.g. useful when the layer has a
+    # different behavior at training and testing time).
+    if has_arg(layer.call, 'training'):
+        model.compile('rmsprop', 'mse')
+        model.train_on_batch(input_data, actual_output)
 
-    # test as first layer in Sequential API
+    # test instantiation from layer config
     layer_config = layer.get_config()
     layer_config['batch_input_shape'] = input_shape
     layer = layer.__class__.from_config(layer_config)
 
-    model = Sequential()
-    model.add(layer)
-    actual_output = model.predict(input_data)
-    actual_output_shape = actual_output.shape
-    for expected_dim, actual_dim in zip(expected_output_shape,
-                                        actual_output_shape):
-        if expected_dim is not None:
-            assert expected_dim == actual_dim
-    if expected_output is not None:
-        if tolerance is not None:
-            assert_allclose(actual_output, expected_output, rtol=1e-3)
-
-    # test serialization, weight setting at model level
-    model_config = model.get_config()
-    recovered_model = Sequential.from_config(model_config)
-    if model.weights:
-        weights = model.get_weights()
-        recovered_model.set_weights(weights)
-        _output = recovered_model.predict(input_data)
-        if tolerance is not None:
-            assert_allclose(_output, actual_output, rtol=1e-3)
-
-    # test training mode (e.g. useful for dropout tests)
-    model.compile('rmsprop', 'mse')
-    model.train_on_batch(input_data, actual_output)
-
     # for further checks in the caller function
     return actual_output
+
+
+def has_arg(fn, name, accept_all=False):
+    """Checks if a callable accepts a given keyword argument.
+
+    For Python 2, checks if there is an argument with the given name.
+
+    For Python 3, checks if there is an argument with the given name, and
+    also whether this argument can be called with a keyword (i.e. if it is
+    not a positional-only argument).
+
+    This function is a copy of the one in keras-team/keras because it's not
+    in the public API.
+
+    # Arguments
+        fn: Callable to inspect.
+        name: Check if `fn` can be called with `name` as a keyword argument.
+        accept_all: What to return if there is no parameter called `name`
+                    but the function accepts a `**kwargs` argument.
+
+    # Returns
+        bool, whether `fn` accepts a `name` keyword argument.
+    """
+    if sys.version_info < (3,):
+        arg_spec = inspect.getargspec(fn)
+        if accept_all and arg_spec.keywords is not None:
+            return True
+        return name in arg_spec.args
+    elif sys.version_info < (3, 3):
+        arg_spec = inspect.getfullargspec(fn)
+        if accept_all and arg_spec.varkw is not None:
+            return True
+        return (name in arg_spec.args or
+                name in arg_spec.kwonlyargs)
+    else:
+        signature = inspect.signature(fn)
+        parameter = signature.parameters.get(name)
+        if parameter is None:
+            if accept_all:
+                for param in signature.parameters.values():
+                    if param.kind == inspect.Parameter.VAR_KEYWORD:
+                        return True
+            return False
+        return (parameter.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                                   inspect.Parameter.KEYWORD_ONLY))

--- a/tests/keras_contrib/layers/test_advanced_activations.py
+++ b/tests/keras_contrib/layers/test_advanced_activations.py
@@ -1,5 +1,5 @@
 import pytest
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from keras_contrib.layers import advanced_activations
 
 

--- a/tests/keras_contrib/layers/test_core.py
+++ b/tests/keras_contrib/layers/test_core.py
@@ -6,7 +6,7 @@ from keras import constraints
 from keras.models import Sequential
 from keras import backend as K
 from keras_contrib.layers import core
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from numpy.testing import assert_allclose
 
 

--- a/tests/keras_contrib/layers/test_embeddings.py
+++ b/tests/keras_contrib/layers/test_embeddings.py
@@ -1,5 +1,5 @@
 import pytest
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from keras.layers.embeddings import Embedding
 import keras.backend as K
 import keras_contrib.backend as KC

--- a/tests/keras_contrib/layers/test_local.py
+++ b/tests/keras_contrib/layers/test_local.py
@@ -1,6 +1,6 @@
 import pytest
 
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from keras_contrib.layers import local
 
 

--- a/tests/keras_contrib/layers/test_noise.py
+++ b/tests/keras_contrib/layers/test_noise.py
@@ -1,5 +1,5 @@
 import pytest
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from keras_contrib.layers import noise
 
 

--- a/tests/keras_contrib/layers/test_normalization.py
+++ b/tests/keras_contrib/layers/test_normalization.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 
 from keras.layers import Dense, Activation, Input
 from keras import regularizers
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from keras_contrib.layers import normalization
 from keras.models import Sequential, Model
 from keras import backend as K

--- a/tests/keras_contrib/layers/test_recurrent.py
+++ b/tests/keras_contrib/layers/test_recurrent.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from keras.utils.test_utils import layer_test
+from keras_contrib.utils.test_utils import layer_test
 from keras_contrib.layers import recurrent
 from keras.layers import embeddings
 from keras.models import Sequential


### PR DESCRIPTION
We shouldn't depend on keras functions which are not in the public API otherwise it won't work for tf.keras.