### PR TITLE
Copied version of normalize_data_format from keras-team.

### DIFF
--- a/keras_contrib/layers/convolutional.py
+++ b/keras_contrib/layers/convolutional.py
@@ -12,7 +12,7 @@ from keras.layers import Layer
 from keras.layers import InputSpec
 from keras.utils import get_custom_objects
 from keras_contrib.utils.conv_utils import conv_output_length
-from keras.backend.common import normalize_data_format
+from keras_contrib.utils.conv_utils import normalize_data_format
 import numpy as np
 
 

--- a/keras_contrib/utils/conv_utils.py
+++ b/keras_contrib/utils/conv_utils.py
@@ -1,3 +1,6 @@
+import keras.backend as K
+
+
 def conv_output_length(input_length, filter_size,
                        padding, stride, dilation=1):
     """Determines output length of a convolution given input length.
@@ -28,3 +31,36 @@ def conv_output_length(input_length, filter_size,
     elif padding == 'full':
         output_length = input_length + dilated_filter_size - 1
     return (output_length + stride - 1) // stride
+
+
+def normalize_data_format(value):
+    """Checks that the value correspond to a valid data format.
+
+    Copy of the function in keras-team/keras because it's not public API.
+
+    # Arguments
+        value: String or None. `'channels_first'` or `'channels_last'`.
+
+    # Returns
+        A string, either `'channels_first'` or `'channels_last'`
+
+    # Example
+    ```python
+        >>> from keras import backend as K
+        >>> K.normalize_data_format(None)
+        'channels_first'
+        >>> K.normalize_data_format('channels_last')
+        'channels_last'
+    ```
+
+    # Raises
+        ValueError: if `value` or the global `data_format` invalid.
+    """
+    if value is None:
+        value = K.image_data_format()
+    data_format = value.lower()
+    if data_format not in {'channels_first', 'channels_last'}:
+        raise ValueError('The `data_format` argument must be one of '
+                         '"channels_first", "channels_last". Received: ' +
+                         str(value))
+    return data_format


### PR DESCRIPTION
If we use functions which are not in the public API, it's going to break when converting to tf.keras