### PR TITLE
Exclude lib site-packages from overall coverage score

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/keras-team/keras-contrib/blob/master/CONTRIBUTING.md
+-->
+
+### Summary
+
+### Related Issues
+
+### PR Overview
+
+- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
+- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
+- [ ] This PR is backwards compatible [y/n]
+- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,21 @@
 <!--
 Please make sure you've read and understood our contributing guidelines;
-https://github.com/keras-team/keras-contrib/blob/master/CONTRIBUTING.md
+https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
 -->
 
-### Summary
+**- What I did**
 
-### Related Issues
 
-### PR Overview
+**- How I did it**
 
-- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
-- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
-- [ ] This PR is backwards compatible [y/n]
-- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
+
+**- How you can verify it**
+<!-- 
+You need a good justification for not including tests if your pull request is 
+a bug fix or adds a new feature to Keras. 
+-->
+
+
+
+---
+This pull request fixes #issue_number_here

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Please make sure you've read and understood our contributing guidelines;
-https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
+https://github.com/keras-team/keras-contrib/blob/master/CONTRIBUTING.md
 -->
 
 **- What I did**
@@ -12,7 +12,7 @@ https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
 **- How you can verify it**
 <!-- 
 You need a good justification for not including tests if your pull request is 
-a bug fix or adds a new feature to Keras. 
+a bug fix or adds a new feature to Keras-contrib. 
 -->
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,6 @@ addopts=-v
         -n 2
         --durations=10
         --cov-report term-missing
-        --cov=keras
 
 # Do not run tests in the build folder
 norecursedirs= build


### PR DESCRIPTION
At the moment, some site-packages are in the cov summary, which shouldn't be the case. This PR fixes the computation of coverage score. 