### PR TITLE
Removing the usage of get_custom_objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,7 @@ model.fit(x=np.random.random((100, 10)), y=np.random.random((100, 100)), epochs=
 # Save our model
 model.save('example.h5')
 ```
-```python
-from keras.models import load_model
-from keras_contrib.layers.advanced_activations import PELU
 
-# Load our model
-model = load_model('example.h5')
-```
 
 ### A Common "Gotcha"
 
@@ -69,11 +63,10 @@ As Keras-Contrib is external to the Keras core, loading a model requires a bit m
 from keras.models import load_model
 
 # Recommended method; requires knowledge of the underlying architecture of the model
-from keras_contrib.layers.advanced_activations import PELU
-
-# Not recommended; however this will correctly find the necessary contrib modules
-from keras_contrib import *
+from keras_contrib.layers import PELU
+from keras_contrib.layers import GroupNormalization
 
 # Load our model
-model = load_model('example.h5')
+custom_objects = {'PELU': PELU, 'GroupNormalization': GroupNormalization}
+model = load_model('example.h5', custom_objects)
 ```

--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -4,7 +4,6 @@ from keras import constraints
 from keras.layers import Layer
 from keras.layers import InputSpec
 from keras import backend as K
-from keras.utils import get_custom_objects
 
 
 class PELU(Layer):
@@ -121,9 +120,6 @@ class PELU(Layer):
 
     def compute_output_shape(self, input_shape):
         return input_shape
-
-
-get_custom_objects().update({'PELU': PELU})
 
 
 class SReLU(Layer):
@@ -251,9 +247,6 @@ class SReLU(Layer):
         return input_shape
 
 
-get_custom_objects().update({'SReLU': SReLU})
-
-
 class Swish(Layer):
     """ Swish (Ramachandranet al., 2017)
 
@@ -302,9 +295,6 @@ class Swish(Layer):
 
     def compute_output_shape(self, input_shape):
         return input_shape
-
-
-get_custom_objects().update({'Swish': Swish})
 
 
 class SineReLU(Layer):
@@ -423,6 +413,3 @@ class SineReLU(Layer):
 
     def compute_output_shape(self, input_shape):
         return input_shape
-
-
-get_custom_objects().update({'SineReLU': SineReLU})

--- a/keras_contrib/layers/convolutional.py
+++ b/keras_contrib/layers/convolutional.py
@@ -10,7 +10,6 @@ from keras import regularizers
 from keras import constraints
 from keras.layers import Layer
 from keras.layers import InputSpec
-from keras.utils import get_custom_objects
 from keras_contrib.utils.conv_utils import conv_output_length
 from keras_contrib.utils.conv_utils import normalize_data_format
 import numpy as np
@@ -251,8 +250,6 @@ class CosineConvolution2D(Layer):
 
 
 CosineConv2D = CosineConvolution2D
-get_custom_objects().update({'CosineConvolution2D': CosineConvolution2D})
-get_custom_objects().update({'CosineConv2D': CosineConv2D})
 
 
 class SubPixelUpscaling(Layer):
@@ -347,6 +344,3 @@ class SubPixelUpscaling(Layer):
                   'data_format': self.data_format}
         base_config = super(SubPixelUpscaling, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-
-get_custom_objects().update({'SubPixelUpscaling': SubPixelUpscaling})

--- a/keras_contrib/layers/core.py
+++ b/keras_contrib/layers/core.py
@@ -9,7 +9,6 @@ from keras import regularizers
 from keras import constraints
 from keras.layers import InputSpec
 from keras.layers import Layer
-from keras.utils import get_custom_objects
 
 
 class CosineDense(Layer):
@@ -177,6 +176,3 @@ class CosineDense(Layer):
         }
         base_config = super(CosineDense, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-
-get_custom_objects().update({'CosineDense': CosineDense})

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -2,7 +2,6 @@ from keras.layers import Layer, InputSpec
 from keras import initializers, regularizers, constraints
 from keras import backend as K
 from keras_contrib import backend as KC
-from keras.utils import get_custom_objects
 
 
 class InstanceNormalization(Layer):
@@ -147,9 +146,6 @@ class InstanceNormalization(Layer):
         }
         base_config = super(InstanceNormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-
-get_custom_objects().update({'InstanceNormalization': InstanceNormalization})
 
 
 class BatchRenormalization(Layer):
@@ -409,9 +405,6 @@ class BatchRenormalization(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-get_custom_objects().update({'BatchRenormalization': BatchRenormalization})
-
-
 class GroupNormalization(Layer):
     """Group normalization layer.
 
@@ -599,6 +592,3 @@ class GroupNormalization(Layer):
 
     def compute_output_shape(self, input_shape):
         return input_shape
-
-
-get_custom_objects().update({'GroupNormalization': GroupNormalization})

--- a/keras_contrib/optimizers/ftml.py
+++ b/keras_contrib/optimizers/ftml.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from keras.optimizers import Optimizer
 from keras import backend as K
-from keras.utils import get_custom_objects
 
 
 class FTML(Optimizer):
@@ -79,6 +78,3 @@ class FTML(Optimizer):
                   'epsilon': self.epsilon}
         base_config = super(FTML, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-
-get_custom_objects().update({'FTML': FTML})

--- a/keras_contrib/optimizers/padam.py
+++ b/keras_contrib/optimizers/padam.py
@@ -1,6 +1,5 @@
 from keras import backend as K
 from keras.optimizers import Optimizer
-from keras.utils import get_custom_objects
 
 
 class Padam(Optimizer):
@@ -101,6 +100,3 @@ class Padam(Optimizer):
                   'partial': self.partial}
         base_config = super(Padam, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-
-get_custom_objects().update({'Padam': Padam})

--- a/keras_contrib/optimizers/yogi.py
+++ b/keras_contrib/optimizers/yogi.py
@@ -1,6 +1,5 @@
 from keras import backend as K
 from keras.optimizers import Optimizer
-from keras.utils import get_custom_objects
 
 
 class Yogi(Optimizer):
@@ -87,6 +86,3 @@ class Yogi(Optimizer):
                   'epsilon': self.epsilon}
         base_config = super(Yogi, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-
-get_custom_objects().update({'Yogi': Yogi})

--- a/keras_contrib/utils/test_utils.py
+++ b/keras_contrib/utils/test_utils.py
@@ -97,7 +97,8 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
 
     # test serialization, weight setting at model level
     model_config = model.get_config()
-    recovered_model = model.__class__.from_config(model_config)
+    custom_objects = {layer.__class__.__name__: layer.__class__}
+    recovered_model = model.__class__.from_config(model_config, custom_objects)
     if model.weights:
         weights = model.get_weights()
         recovered_model.set_weights(weights)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras-contrib/blob/master/CONTRIBUTING.md
-->

**- What I did**

I removed the modifications of global objects at import time.

**- How I did it**
removed the stuff and updated the readme.

**- How you can verify it**
<!-- 
You need a good justification for not including tests if your pull request is 
a bug fix or adds a new feature to Keras-contrib. 
-->

Now the new test is using custom objects. Both optimizers and layers have tests where they are put in json and loaded back.

