### PR TITLE
Adds Application Tests

### DIFF
--- a/keras_contrib/applications/nasnet.py
+++ b/keras_contrib/applications/nasnet.py
@@ -153,11 +153,6 @@ def NASNet(input_shape=None,
         RuntimeError: If attempting to run this model with a
             backend that does not support separable convolutions.
     """
-    if K.backend() != 'tensorflow':
-        raise RuntimeError('Only Tensorflow backend is currently supported, '
-                           'as other backends do not support '
-                           'separable convolution.')
-
     if weights not in {'imagenet', None}:
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization) or `imagenet` '

--- a/keras_contrib/applications/nasnet.py
+++ b/keras_contrib/applications/nasnet.py
@@ -1,9 +1,7 @@
 """Collection of NASNet models
-
 The reference paper:
  - [Learning Transferable Architectures for Scalable Image Recognition]
     (https://arxiv.org/abs/1707.07012)
-
 The reference implementation:
 1. TF Slim
  - https://github.com/tensorflow/models/blob/master/research/slim/nets/
@@ -40,6 +38,7 @@ from keras.regularizers import l2
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
 from keras_applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import preprocess_input as _preprocess_input
 from keras import backend as K
 
 _BN_DECAY = 0.9997
@@ -53,6 +52,18 @@ NASNET_LARGE_WEIGHT_PATH = "https://github.com/titu1994/Keras-NASNet/releases/do
 NASNET_LARGE_WEIGHT_PATH_NO_TOP = "https://github.com/titu1994/Keras-NASNet/releases/download/v1.1/NASNet-large-no-top.h5"
 NASNET_LARGE_WEIGHT_PATH_WITH_auxiliary = "https://github.com/titu1994/Keras-NASNet/releases/download/v1.1/NASNet-auxiliary-large.h5"
 NASNET_LARGE_WEIGHT_PATH_WITH_auxiliary_NO_TOP = "https://github.com/titu1994/Keras-NASNet/releases/download/v1.1/NASNet-auxiliary-large-no-top.h5"
+
+
+def preprocess_input(x, **kwargs):
+    """Preprocesses a numpy array encoding a batch of images.
+    # Arguments
+        x: a 4D numpy array consists of RGB values within [0, 255].
+    # Returns
+        Preprocessed array.
+    """
+    if 'backend' not in kwargs:
+        kwargs['backend'] = K
+    return _preprocess_input(x, mode='tf', **kwargs)
 
 
 def NASNet(input_shape=None,
@@ -77,7 +88,6 @@ def NASNet(input_shape=None,
     therefore it only works with the data format
     `image_data_format='channels_last'` in your Keras config
     at `~/.keras/keras.json`.
-
     # Arguments
         input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
@@ -326,7 +336,6 @@ def NASNetLarge(input_shape=(331, 331, 3),
     therefore it only works with the data format
     `image_data_format='channels_last'` in your Keras config
     at `~/.keras/keras.json`.
-
     # Arguments
         input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
@@ -409,7 +418,6 @@ def NASNetMobile(input_shape=(224, 224, 3),
     therefore it only works with the data format
     `image_data_format='channels_last'` in your Keras config
     at `~/.keras/keras.json`.
-
     # Arguments
         input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
@@ -491,7 +499,6 @@ def NASNetCIFAR(input_shape=(32, 32, 3),
     therefore it only works with the data format
     `image_data_format='channels_last'` in your Keras config
     at `~/.keras/keras.json`.
-
     # Arguments
         input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
@@ -561,7 +568,6 @@ def NASNetCIFAR(input_shape=(32, 32, 3),
 
 def _separable_conv_block(ip, filters, kernel_size=(3, 3), strides=(1, 1), weight_decay=5e-5, id=None):
     '''Adds 2 blocks of [relu-separable conv-batchnorm]
-
     # Arguments:
         ip: input tensor
         filters: number of output filters per layer
@@ -569,7 +575,6 @@ def _separable_conv_block(ip, filters, kernel_size=(3, 3), strides=(1, 1), weigh
         strides: strided convolution for downsampling
         weight_decay: l2 regularization weight
         id: string id
-
     # Returns:
         a Keras tensor
     '''
@@ -596,14 +601,12 @@ def _adjust_block(p, ip, filters, weight_decay=5e-5, id=None):
     Adjusts the input `p` to match the shape of the `input`
     or situations where the output number of filters needs to
     be changed
-
     # Arguments:
         p: input tensor which needs to be modified
         ip: input tensor whose shape needs to be matched
         filters: number of output filters to be matched
         weight_decay: l2 regularization weight
         id: string id
-
     # Returns:
         an adjusted Keras tensor
     '''
@@ -644,14 +647,12 @@ def _adjust_block(p, ip, filters, weight_decay=5e-5, id=None):
 
 def _normal_A(ip, p, filters, weight_decay=5e-5, id=None):
     '''Adds a Normal cell for NASNet-A (Fig. 4 in the paper)
-
     # Arguments:
         ip: input tensor `x`
         p: input tensor `p`
         filters: number of output filters
         weight_decay: l2 regularization weight
         id: string id
-
     # Returns:
         a Keras tensor
     '''
@@ -696,14 +697,12 @@ def _normal_A(ip, p, filters, weight_decay=5e-5, id=None):
 
 def _reduction_A(ip, p, filters, weight_decay=5e-5, id=None):
     '''Adds a Reduction cell for NASNet-A (Fig. 4 in the paper)
-
     # Arguments:
         ip: input tensor `x`
         p: input tensor `p`
         filters: number of output filters
         weight_decay: l2 regularization weight
         id: string id
-
     # Returns:
         a Keras tensor
     '''
@@ -753,11 +752,9 @@ def _reduction_A(ip, p, filters, weight_decay=5e-5, id=None):
 
 def _add_auxiliary_head(x, classes, weight_decay, pooling, include_top, activation):
     '''Adds an auxiliary head for training the model
-
     From section A.7 "Training of ImageNet models" of the paper, all NASNet models are
     trained using an auxiliary classifier around 2/3 of the depth of the network, with
     a loss weight of 0.4
-
     # Arguments
         x: input tensor
         classes: number of output classes
@@ -778,7 +775,6 @@ def _add_auxiliary_head(x, classes, weight_decay, pooling, include_top, activati
             layer at the top of the network.
         activation: Type of activation at the top layer.
             Can be one of 'softmax' or 'sigmoid'.
-
     # Returns
         a keras Tensor
     '''

--- a/keras_contrib/applications/resnet.py
+++ b/keras_contrib/applications/resnet.py
@@ -1,17 +1,12 @@
 """ResNet v1, v2, and segmentation models for Keras.
-
 # Reference
-
 - [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385)
 - [Identity Mappings in Deep Residual Networks](https://arxiv.org/abs/1603.05027)
-
 Reference material for extended functionality:
-
 - [ResNeXt](https://arxiv.org/abs/1611.05431) for Tiny ImageNet support.
 - [Dilated Residual Networks](https://arxiv.org/pdf/1705.09914) for segmentation support.
 - [Deep Residual Learning for Instrument Segmentation in Robotic Surgery](https://arxiv.org/abs/1703.08580)
   for segmentation support.
-
 Implementation Adapted from: github.com/raghakot/keras-resnet
 """
 from __future__ import division
@@ -32,6 +27,20 @@ from keras.layers.normalization import BatchNormalization
 from keras.regularizers import l2
 from keras import backend as K
 from keras_applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import preprocess_input as _preprocess_input
+
+
+def preprocess_input(x, **kwargs):
+    """Preprocesses a numpy array encoding a batch of images.
+    # Arguments
+        x: a 4D numpy array consists of RGB values within [0, 255].
+        data_format: data format of the image tensor.
+    # Returns
+        Preprocessed array.
+    """
+    if 'backend' not in kwargs:
+        kwargs['backend'] = K
+    return _preprocess_input(x, mode='caffe', **kwargs)
 
 
 def _bn_relu(x, bn_name=None, relu_name=None):
@@ -132,7 +141,6 @@ def _residual_block(block_function, filters, blocks, stage,
                     dilation_rates=None, is_first_layer=False, dropout=None,
                     residual_unit=_bn_relu_conv):
     """Builds a residual block with repeating bottleneck blocks.
-
        stage: integer, current stage label, used for generating layer names
        blocks: number of blocks 'a','b'..., current block label, used for generating layer names
        transition_strides: a list of tuples for the strides of each transition
@@ -160,7 +168,6 @@ def _residual_block(block_function, filters, blocks, stage,
 
 def _block_name_base(stage, block):
     """Get the convolution name base and batch normalization name base defined by stage and block.
-
     If there are less than 26 blocks they will be labeled 'a', 'b', 'c' to match the paper and keras
     and beyond 26 blocks they will simply be numbered.
     """
@@ -212,7 +219,6 @@ def bottleneck(filters, stage, block, transition_strides=(1, 1),
                residual_unit=_bn_relu_conv):
     """Bottleneck architecture for > 34 layer resnet.
     Follows improved proposed scheme in http://arxiv.org/pdf/1603.05027v2.pdf
-
     Returns:
         A final conv layer of filters * 4
     """
@@ -279,9 +285,8 @@ def _string_to_function(identifier):
 def ResNet(input_shape=None, classes=10, block='bottleneck', residual_unit='v2', repetitions=None,
            initial_filters=64, activation='softmax', include_top=True, input_tensor=None, dropout=None,
            transition_dilation_rate=(1, 1), initial_strides=(2, 2), initial_kernel_size=(7, 7),
-           initial_pooling='max', final_pooling=None, top='classification'):
+           initial_pooling='max', final_pooling=None, top='classification', **kwargs):
     """Builds a custom ResNet like architecture. Defaults to ResNet50 v2.
-
     Args:
         input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
@@ -326,7 +331,6 @@ def ResNet(input_shape=None, classes=10, block='bottleneck', residual_unit='v2',
         top: Defines final layers to evaluate based on a specific problem type. Options are
             'classification' for ImageNet style problems, 'segmentation' for problems like
             the Pascal VOC dataset, and None to exclude these layers entirely.
-
     Returns:
         The keras `Model`.
     """
@@ -422,31 +426,34 @@ def ResNet(input_shape=None, classes=10, block='bottleneck', residual_unit='v2',
     return model
 
 
-def ResNet18(input_shape, classes):
+def ResNet18(input_shape=None, classes=10, **kwargs):
     """ResNet with 18 layers and v2 residual units
     """
-    return ResNet(input_shape, classes, basic_block, repetitions=[2, 2, 2, 2])
+    print("Input shape : ", input_shape)
+    print("Classes", classes)
+    print("kwargs", kwargs)
+    return ResNet(input_shape, classes, basic_block, repetitions=[2, 2, 2, 2], **kwargs)
 
 
-def ResNet34(input_shape, classes):
+def ResNet34(input_shape=None, classes=10, **kwargs):
     """ResNet with 34 layers and v2 residual units
     """
-    return ResNet(input_shape, classes, basic_block, repetitions=[3, 4, 6, 3])
+    return ResNet(input_shape, classes, basic_block, repetitions=[3, 4, 6, 3], **kwargs)
 
 
-def ResNet50(input_shape, classes):
+def ResNet50(input_shape=None, classes=10, **kwargs):
     """ResNet with 50 layers and v2 residual units
     """
-    return ResNet(input_shape, classes, bottleneck, repetitions=[3, 4, 6, 3])
+    return ResNet(input_shape, classes, bottleneck, repetitions=[3, 4, 6, 3], **kwargs)
 
 
-def ResNet101(input_shape, classes):
+def ResNet101(input_shape=None, classes=10, **kwargs):
     """ResNet with 101 layers and v2 residual units
     """
-    return ResNet(input_shape, classes, bottleneck, repetitions=[3, 4, 23, 3])
+    return ResNet(input_shape, classes, bottleneck, repetitions=[3, 4, 23, 3], **kwargs)
 
 
-def ResNet152(input_shape, classes):
+def ResNet152(input_shape=None, classes=10, **kwargs):
     """ResNet with 152 layers and v2 residual units
     """
-    return ResNet(input_shape, classes, bottleneck, repetitions=[3, 8, 36, 3])
+    return ResNet(input_shape, classes, bottleneck, repetitions=[3, 8, 36, 3], **kwargs)

--- a/keras_contrib/applications/resnet.py
+++ b/keras_contrib/applications/resnet.py
@@ -173,8 +173,8 @@ def _block_name_base(stage, block):
     """
     if block < 27:
         block = '%c' % (block + 97)  # 97 is the ascii number for lowercase 'a'
-    conv_name_base = 'res' + str(stage) + block + '_branch'
-    bn_name_base = 'bn' + str(stage) + block + '_branch'
+    conv_name_base = 'res' + str(stage) + str(block) + '_branch'
+    bn_name_base = 'bn' + str(stage) + str(block) + '_branch'
     return conv_name_base, bn_name_base
 
 

--- a/keras_contrib/applications/wide_resnet.py
+++ b/keras_contrib/applications/wide_resnet.py
@@ -108,7 +108,7 @@ def WideResidualNetwork(depth=28, width=8, dropout_rate=0.0,
     input_shape = _obtain_input_shape(input_shape,
                                       default_size=32,
                                       min_size=8,
-                                      data_format=K.image_dim_ordering(),
+                                      data_format=K.image_data_format(),
                                       require_flatten=include_top)
 
     if input_tensor is None:
@@ -136,7 +136,7 @@ def WideResidualNetwork(depth=28, width=8, dropout_rate=0.0,
         if (depth == 28) and (width == 8) and (dropout_rate == 0.0):
             # Default parameters match. Weights for this model exist:
 
-            if K.image_dim_ordering() == 'th':
+            if K.image_data_format() == 'channels_first':
                 if include_top:
                     weights_path = get_file('wide_resnet_28_8_th_dim_ordering_th_kernels.h5',
                                             TH_WEIGHTS_PATH,
@@ -245,10 +245,10 @@ def __conv3_block(input, k=1, dropout=0.0):
 def ___conv4_block(input, k=1, dropout=0.0):
     init = input
 
-    channel_axis = 1 if K.image_dim_ordering() == 'th' else -1
+    channel_axis = 1 if K.image_data_format() == 'channels_first' else -1
 
     # Check if input number of filters is same as 64 * k, else create convolution2d for this input
-    if K.image_dim_ordering() == 'th':
+    if K.image_data_format() == 'channels_first':
         if init._keras_shape[1] != 64 * k:
             init = Conv2D(64 * k, (1, 1), activation='linear', padding='same')(init)
     else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        -n 2
+        # -n 2
         --durations=10
         --cov-report term-missing
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        # -n 2
+        -n 2
         --durations=10
         --cov-report term-missing
 

--- a/tests/keras_contrib/applications/applications_test.py
+++ b/tests/keras_contrib/applications/applications_test.py
@@ -1,0 +1,235 @@
+import random
+from multiprocessing import Process, Queue
+
+import numpy as np
+import pytest
+import six
+from keras import backend as K
+
+from keras_contrib.applications import densenet
+from keras_contrib.applications import nasnet
+from keras_contrib.applications import resnet
+from keras_contrib.applications import wide_resnet
+
+DENSENET_LIST = [(densenet.DenseNetImageNet121, 1024),
+                 (densenet.DenseNetImageNet169, 1664),
+                 (densenet.DenseNetImageNet161, 2208),
+                 # (densenet.DenseNetImageNet201, 1920),  # DenseNet201 is too heavy to test on Travis
+                 # (densenet.DenseNetImageNet264, 2688)  # DenseNet264 is too heavy to test on Travis
+                 ]
+
+NASNET_LIST = [(nasnet.NASNetMobile, 1056, 1000),  # NASNetLarge is too heavy to test on Travis
+               (nasnet.NASNetCIFAR, 768, 10)]
+
+RESNET_LIST = [resnet.ResNet18,
+               resnet.ResNet34,
+               resnet.ResNet50,
+               resnet.ResNet101,
+               resnet.ResNet152]
+
+WIDE_RESNET_LIST = [wide_resnet.WideResidualNetwork]
+
+
+def keras_test(func):
+    """Function wrapper to clean up after TensorFlow tests.
+    # Arguments
+        func: test function to clean up after.
+    # Returns
+        A function wrapping the input function.
+    """
+    @six.wraps(func)
+    def wrapper(*args, **kwargs):
+        output = func(*args, **kwargs)
+        if K.backend() == 'tensorflow' or K.backend() == 'cntk':
+            K.clear_session()
+        return output
+    return wrapper
+
+
+def _get_input_shape(target_size):
+    """
+    Compute the input shape dependent on the backend
+    image data format.
+    """
+    if K.image_data_format() == 'channels_first':
+        input_shape = [1, 3] + list(target_size)
+    else:
+        input_shape = [1] + list(target_size) + [3]
+
+    return input_shape
+
+
+def _get_noise_input(target_size):
+    # For models that don't include a Flatten step,
+    # the default is to accept variable-size inputs
+    # even when loading ImageNet weights (since it is possible).
+    # In this case, default to 299x299.
+    if target_size[0] is None:
+        target_size = (299, 299)
+    input_shape = _get_input_shape(target_size)
+
+    state = np.random.get_state()
+    np.random.seed(0)
+
+    img = np.random.uniform(low=0.0, high=255., size=input_shape)
+
+    np.random.set_state(state)
+
+    return img
+
+
+def _get_output_shape(model_fn, preprocess_input=None):
+    if K.backend() == 'cntk':
+        # Create model in a subprocess so that
+        # the memory consumed by InceptionResNetV2 will be
+        # released back to the system after this test
+        # (to deal with OOM error on CNTK backend).
+        # TODO: remove the use of multiprocessing from these tests
+        # once a memory clearing mechanism
+        # is implemented in the CNTK backend.
+        def target(queue):
+            model = model_fn()
+            if preprocess_input is None:
+                queue.put(model.output_shape)
+            else:
+                x = _get_noise_input(model.input_shape[1:3])
+                x = preprocess_input(x)
+                queue.put((model.output_shape, model.predict(x)))
+        queue = Queue()
+        p = Process(target=target, args=(queue,))
+        p.start()
+        p.join()
+        # The error in a subprocess won't propagate
+        # to the main process, so we check if the model
+        # is successfully created by checking if the output shape
+        # has been put into the queue
+        assert not queue.empty(), 'Model creation failed.'
+        return queue.get_nowait()
+    else:
+        model = model_fn()
+        if preprocess_input is None:
+            return model.output_shape
+        else:
+            x = _get_noise_input(model.input_shape[1:3])
+            x = preprocess_input(x)
+            return (model.output_shape, model.predict(x))
+
+
+@keras_test
+def _test_application_basic(app, last_dim=1000, module=None, **kwargs):
+    if module is None:
+        output_shape = _get_output_shape(lambda: app(weights=None, **kwargs))
+        assert output_shape == (None, None, None, last_dim)
+    else:
+        output_shape, preds = _get_output_shape(
+            lambda: app(weights=None, **kwargs), module.preprocess_input)
+        assert output_shape == (None, last_dim)
+
+
+@keras_test
+def _test_application_notop(app, last_dim, **kwargs):
+    output_shape = _get_output_shape(
+        lambda: app(weights=None, include_top=False, **kwargs))
+    assert output_shape == (None, None, None, last_dim)
+
+
+@keras_test
+def _test_application_variable_input_channels(app, last_dim, **kwargs):
+    if 'input_shape' in kwargs:
+        kwargs.pop('input_shape')
+
+    if K.image_data_format() == 'channels_first':
+        input_shape = (1, None, None)
+    else:
+        input_shape = (None, None, 1)
+    output_shape = _get_output_shape(
+        lambda: app(weights=None, include_top=False, input_shape=input_shape, **kwargs))
+    assert output_shape == (None, None, None, last_dim)
+
+    if K.image_data_format() == 'channels_first':
+        input_shape = (4, None, None)
+    else:
+        input_shape = (None, None, 4)
+    output_shape = _get_output_shape(
+        lambda: app(weights=None, include_top=False, input_shape=input_shape, **kwargs))
+    assert output_shape == (None, None, None, last_dim)
+
+
+@keras_test
+def _test_app_pooling(app, last_dim, **kwargs):
+    output_shape = _get_output_shape(
+        lambda: app(weights=None,
+                    include_top=False,
+                    pooling=random.choice(['avg', 'max']),
+                    **kwargs))
+    assert output_shape == (None, last_dim)
+
+
+def test_resnet():
+    app = random.choice(RESNET_LIST)
+    module = resnet
+    input_shape = _get_input_shape((32, 32))[1:]  # remove batch dimension
+    classes = 10
+    last_dim = 512
+    app_args = dict(input_shape=input_shape,
+                    classes=classes)
+
+    _test_application_basic(app, last_dim=classes, module=module, **app_args)
+
+    # _test_application_notop equivalent
+    output_shape = _get_output_shape(
+        lambda: app(weights=None, include_top=False, **app_args))
+    output_shape = list(output_shape)
+    output_shape[1:-1] = [None, None]  # we disregard image dimensions
+    assert output_shape == [None, None, None, last_dim]
+
+    # skipping variable input channels for resnet
+    # _test_application_variable_input_channels(app, last_dim, **app_args)
+
+    # skipping pooling parameters for resnet
+    # _test_app_pooling(app, last_dim, **app_args)
+
+
+def test_wide_resnet():
+    app = random.choice(WIDE_RESNET_LIST)
+    module = wide_resnet
+    last_dim = 512
+    classes = 10
+    _test_application_basic(app, classes,  module=module)
+    _test_application_notop(app, last_dim)
+    _test_application_variable_input_channels(app, last_dim)
+    _test_app_pooling(app, last_dim)
+
+
+def test_densenet():
+    app, last_dim = random.choice(DENSENET_LIST)
+    module = densenet
+    app_args = dict(pooling='avg')
+    # basic model returns (None, 1, 1, classes), therefore we
+    # add `avg` pooling to force (None, classes) behaviour.
+    _test_application_basic(app, module=module, **app_args)
+    _test_application_notop(app, last_dim)
+    _test_application_variable_input_channels(app, last_dim)
+    _test_app_pooling(app, last_dim)
+
+
+def test_nasnet():
+    app, last_dim, classes = random.choice(NASNET_LIST)
+    module = nasnet
+    _test_application_basic(app, classes, module=module)
+
+    # _test_application_notop equivalent
+    output_shape = _get_output_shape(
+        lambda: app(weights=None, include_top=False))
+    output_shape = list(output_shape)
+    output_shape[1:-1] = [None, None]  # we disregard image dimensions
+    assert output_shape == [None, None, None, last_dim]
+
+    # NASNet models do not support variable input shapes
+    # _test_application_variable_input_channels(app, last_dim)
+
+    _test_app_pooling(app, last_dim)
+
+
+if __name__ == '__main__':
+    pytest.main(__file__)


### PR DESCRIPTION
Adds randomized testing of the models in the application module.

Significant alterations : 

- Adds test suite to randomly test one model of each type - DenseNet, ResNet, NASNet and WideResNet
- Adds the `preprocess_input` function to all modules, derived from keras_application's preprocess_input
- Adds `pooling` argument to WideResNet builder to be compatible with tests
- Adds `**kwargs` to ResNet builder to handle 'weights=None' case for tests
- Skips testing of NASNet Large (as it is too heavy to even evaluate on Travis)

One drawback of testing applications is that it incurs significant runtime costs of Travis, even for applications which rarely ever change unless there is a major API change (i.e. Keras 1 -> Keras 2).

Notable exceptions:

- Avoids running certain tests on ResNet. I don't wish to break the current codebase as it has significant complexity so I simply eliminate certain tests. Once the primary author of the scripts takes charge of the ResNet codebase, they can re-enable the tests as seen fit by them.
- Added default settings to ResNet model functions corresponding to the default values in the main builder.