### PR TITLE
Fixing the build by fetching automatically the token.

### DIFF
--- a/tests/tooling/test_codeowners.py
+++ b/tests/tooling/test_codeowners.py
@@ -9,7 +9,6 @@ except ImportError:
 path_to_keras_contrib = pathlib.Path(__file__).resolve().parents[2]
 path_to_codeowners = path_to_keras_contrib / 'CODEOWNERS'
 
-
 authenticated = True
 try:
     github_client = Github(os.environ['GITHUB_TOKEN'])

--- a/tests/tooling/test_codeowners.py
+++ b/tests/tooling/test_codeowners.py
@@ -15,7 +15,8 @@ try:
     github_client = Github(os.environ['GITHUB_TOKEN'])
 except KeyError:
     try:
-        github_client = Github(os.environ['GITHUB_USER'], os.environ['GITHUB_PASSWORD'])
+        github_client = Github(os.environ['GITHUB_USER'],
+                               os.environ['GITHUB_PASSWORD'])
     except KeyError:
         authenticated = False
 

--- a/tests/tooling/test_codeowners.py
+++ b/tests/tooling/test_codeowners.py
@@ -10,15 +10,14 @@ path_to_keras_contrib = pathlib.Path(__file__).resolve().parents[2]
 path_to_codeowners = path_to_keras_contrib / 'CODEOWNERS'
 
 
-def get_github_client():
-    """Uses environment variables to authenticate if they are present."""
+authenticated = True
+try:
+    github_client = Github(os.environ['GITHUB_TOKEN'])
+except KeyError:
     try:
-        return Github(os.environ['GITHUB_TOKEN'])
+        github_client = Github(os.environ['GITHUB_USER'], os.environ['GITHUB_PASSWORD'])
     except KeyError:
-        try:
-            return Github(os.environ['GITHUB_USER'], os.environ['GITHUB_PASSWORD'])
-        except KeyError:
-            return Github()
+        authenticated = False
 
 
 def parse_codeowners():
@@ -39,11 +38,14 @@ def test_codeowners_file_exist():
         assert path.exists()
 
 
+@pytest.mark.skipif(not authenticated,
+                    reason='It should be possible to run the test without'
+                           'authentication, but we might get our request refused'
+                           'by github. To be deterministic, we\'ll disable it.')
 def test_codeowners_user_exist():
-    client = get_github_client()
     for _, user in parse_codeowners():
         assert user[0] == '@'
-        assert client.get_user(user[1:])
+        assert github_client.get_user(user[1:])
 
 
 if __name__ == '__main__':

--- a/tests/tooling/test_codeowners.py
+++ b/tests/tooling/test_codeowners.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from github import Github
 try:
@@ -7,6 +8,17 @@ except ImportError:
 
 path_to_keras_contrib = pathlib.Path(__file__).resolve().parents[2]
 path_to_codeowners = path_to_keras_contrib / 'CODEOWNERS'
+
+
+def get_github_client():
+    """Uses environment variables to authenticate if they are present."""
+    try:
+        return Github(os.environ['GITHUB_TOKEN'])
+    except KeyError:
+        try:
+            return Github(os.environ['GITHUB_USER'], os.environ['GITHUB_PASSWORD'])
+        except KeyError:
+            return Github()
 
 
 def parse_codeowners():
@@ -28,7 +40,7 @@ def test_codeowners_file_exist():
 
 
 def test_codeowners_user_exist():
-    client = Github()
+    client = get_github_client()
     for _, user in parse_codeowners():
         assert user[0] == '@'
         assert client.get_user(user[1:])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras-contrib/blob/master/CONTRIBUTING.md
-->

**- What I did**
Fixing the build.

**- How I did it**
When not autenticated, the github client request can be refused because the IP adress made too many requests. But this limitation can be lifted. I already put a token that I generated on travis to autenticate the client.

The names of the environement variables were taken from the CLI tool of github: https://hub.github.com/hub.1.html .

**- How you can verify it**
<!-- 
You need a good justification for not including tests if your pull request is 
a bug fix or adds a new feature to Keras-contrib. 
-->

The build now passes.
