### PR TITLE
100% original Adam that allows to train x2 or x3 bigger networks.

### DIFF
--- a/keras_contrib/optimizers/adam.py
+++ b/keras_contrib/optimizers/adam.py
@@ -1,0 +1,106 @@
+from keras import backend as K
+from keras.optimizers import Optimizer
+
+class Adam(Optimizer):
+    """Adam optimizer.
+
+    Default parameters follow those provided in the original paper.
+
+    # Arguments
+        lr: float >= 0. Learning rate.
+        beta_1: float, 0 < beta < 1. Generally close to 1.
+        beta_2: float, 0 < beta < 1. Generally close to 1.
+        epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
+        decay: float >= 0. Learning rate decay over each update.
+        amsgrad: boolean. Whether to apply the AMSGrad variant of this
+            algorithm from the paper "On the Convergence of Adam and
+            Beyond".
+        tf_cpu_mode: only for tensorflow backend
+                      0 - default, no changes.
+                      1 - allows to train x2 bigger network on same VRAM consuming RAM
+                      2 - allows to train x3 bigger network on same VRAM consuming RAM*2 and CPU power.
+
+    # References
+        - [Adam - A Method for Stochastic Optimization]
+          (https://arxiv.org/abs/1412.6980v8)
+        - [On the Convergence of Adam and Beyond]
+          (https://openreview.net/forum?id=ryQu7f-RZ)
+    """
+
+    def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999,
+                 epsilon=None, decay=0., amsgrad=False, tf_cpu_mode=0, **kwargs):
+        super(Adam, self).__init__(**kwargs)
+        with K.name_scope(self.__class__.__name__):
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+            self.lr = K.variable(lr, name='lr')
+            self.beta_1 = K.variable(beta_1, name='beta_1')
+            self.beta_2 = K.variable(beta_2, name='beta_2')
+            self.decay = K.variable(decay, name='decay')
+        if epsilon is None:
+            epsilon = K.epsilon()
+        self.epsilon = epsilon
+        self.initial_decay = decay
+        self.amsgrad = amsgrad
+        self.tf_cpu_mode = tf_cpu_mode
+
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        lr = self.lr
+        if self.initial_decay > 0:
+            lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
+                                                      K.dtype(self.decay))))
+
+        t = K.cast(self.iterations, K.floatx()) + 1
+        lr_t = lr * (K.sqrt(1. - K.pow(self.beta_2, t)) /
+                           (1. - K.pow(self.beta_1, t)))
+
+        e = K.tf.device("/cpu:0") if self.tf_cpu_mode > 0 else None
+        if e: e.__enter__()
+        ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        vs = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        if self.amsgrad:
+            vhats = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        else:
+            vhats = [K.zeros(1) for _ in params]
+        if e: e.__exit__(None, None, None)
+        
+        self.weights = [self.iterations] + ms + vs + vhats
+
+        for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):            
+            e = K.tf.device("/cpu:0") if self.tf_cpu_mode == 2 else None
+            if e: e.__enter__()            
+            m_t = (self.beta_1 * m) + (1. - self.beta_1) * g
+            v_t = (self.beta_2 * v) + (1. - self.beta_2) * K.square(g)
+            
+            if self.amsgrad:
+                vhat_t = K.maximum(vhat, v_t)
+                self.updates.append(K.update(vhat, vhat_t))
+            if e: e.__exit__(None, None, None)
+            
+            if self.amsgrad:
+                p_t = p - lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)
+            else:
+                p_t = p - lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
+                
+            self.updates.append(K.update(m, m_t))
+            self.updates.append(K.update(v, v_t))
+            new_p = p_t
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'beta_1': float(K.get_value(self.beta_1)),
+                  'beta_2': float(K.get_value(self.beta_2)),
+                  'decay': float(K.get_value(self.decay)),
+                  'epsilon': self.epsilon,
+                  'amsgrad': self.amsgrad}
+        base_config = super(Adam, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_contrib/optimizers/adam.py
+++ b/keras_contrib/optimizers/adam.py
@@ -1,6 +1,7 @@
 from keras import backend as K
 from keras.optimizers import Optimizer
 
+
 class Adam(Optimizer):
     """Adam optimizer.
 
@@ -18,7 +19,8 @@ class Adam(Optimizer):
         tf_cpu_mode: only for tensorflow backend
                       0 - default, no changes.
                       1 - allows to train x2 bigger network on same VRAM consuming RAM
-                      2 - allows to train x3 bigger network on same VRAM consuming RAM*2 and CPU power.
+                      2 - allows to train x3 bigger network on same VRAM consuming RAM*2
+                          and CPU power.
 
     # References
         - [Adam - A Method for Stochastic Optimization]
@@ -57,27 +59,31 @@ class Adam(Optimizer):
                            (1. - K.pow(self.beta_1, t)))
 
         e = K.tf.device("/cpu:0") if self.tf_cpu_mode > 0 else None
-        if e: e.__enter__()
+        if e:
+            e.__enter__()
         ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
         vs = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
         if self.amsgrad:
             vhats = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
         else:
             vhats = [K.zeros(1) for _ in params]
-        if e: e.__exit__(None, None, None)
+        if e:
+            e.__exit__(None, None, None)
         
         self.weights = [self.iterations] + ms + vs + vhats
 
-        for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):            
+        for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):
             e = K.tf.device("/cpu:0") if self.tf_cpu_mode == 2 else None
-            if e: e.__enter__()            
+            if e:
+                e.__enter__()            
             m_t = (self.beta_1 * m) + (1. - self.beta_1) * g
             v_t = (self.beta_2 * v) + (1. - self.beta_2) * K.square(g)
             
             if self.amsgrad:
                 vhat_t = K.maximum(vhat, v_t)
                 self.updates.append(K.update(vhat, vhat_t))
-            if e: e.__exit__(None, None, None)
+            if e:
+                e.__exit__(None, None, None)
             
             if self.amsgrad:
                 p_t = p - lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)

--- a/keras_contrib/optimizers/adam.py
+++ b/keras_contrib/optimizers/adam.py
@@ -69,27 +69,27 @@ class Adam(Optimizer):
             vhats = [K.zeros(1) for _ in params]
         if e:
             e.__exit__(None, None, None)
-        
+
         self.weights = [self.iterations] + ms + vs + vhats
 
         for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):
             e = K.tf.device("/cpu:0") if self.tf_cpu_mode == 2 else None
             if e:
-                e.__enter__()            
+                e.__enter__()
             m_t = (self.beta_1 * m) + (1. - self.beta_1) * g
             v_t = (self.beta_2 * v) + (1. - self.beta_2) * K.square(g)
-            
+
             if self.amsgrad:
                 vhat_t = K.maximum(vhat, v_t)
                 self.updates.append(K.update(vhat, vhat_t))
             if e:
                 e.__exit__(None, None, None)
-            
+
             if self.amsgrad:
                 p_t = p - lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)
             else:
                 p_t = p - lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
-                
+
             self.updates.append(K.update(m, m_t))
             self.updates.append(K.update(v, v_t))
             new_p = p_t


### PR DESCRIPTION
**- What I did**

added 100% original Adam optimizer with new option
```
tf_cpu_mode: only for tensorflow backend
0 - default, no changes.
1 - allows to train x2 bigger network on same VRAM consuming RAM
2 - allows to train x3 bigger network on same VRAM consuming RAM*2 and CPU power.
```

Batch size is very important parameter for GAN networks. So getting rid of optimizer's weights from VRAM, we can train higher batch size, sacrificing 10-20% of time per iteration.

**- How I did it**

accidentally discovered.


**- How you can verify it**

add `tf_cpu_mode=1` to Adam
and try x2 bigger network
