### PR TITLE
Enforcing dtype in `K.zeros_like` for mask

### DIFF
--- a/keras_contrib/layers/crf.py
+++ b/keras_contrib/layers/crf.py
@@ -513,7 +513,7 @@ class CRF(Layer):
         constants = [chain_energy]
 
         if mask is not None:
-            mask2 = K.cast(K.concatenate([mask, K.zeros_like(mask[:, :1])], axis=1),
+            mask2 = K.cast(K.concatenate([mask, K.cast(K.zeros_like(mask[:, :1]), mask.dtype)], axis=1),
                            K.floatx())
             constants.append(mask2)
 


### PR DESCRIPTION
Enforcing dtype in `K.zeros_like` for mask in `recursion` function. `K.zeros_like` failed to infer dtype of `mask` when a Masking layer is used.

Passed dtype of `mask` as parameter to `K.zeros_like`

This pull request fixes #498 and #515 
