### PR TITLE
fix crf layer mask tensor type ERROR when concatenate

### DIFF
--- a/keras_contrib/layers/crf.py
+++ b/keras_contrib/layers/crf.py
@@ -513,6 +513,7 @@ class CRF(Layer):
         constants = [chain_energy]
 
         if mask is not None:
+            mask = K.cast(mask, K.floatx())
             mask2 = K.cast(K.concatenate([mask, K.zeros_like(mask[:, :1])], axis=1),
                            K.floatx())
             constants.append(mask2)


### PR DESCRIPTION


**- What I did**
fix crf layer mask tensor type ERROR when concatenate
**- How I did it**
cast the tensor to K.floatx like other place do.

**- How you can verify it**
After fix it, my code can run well :)



---
This pull request fixes #issue_number_here
