### PR TITLE
Jaccard Loss Updated

### DIFF
--- a/keras_contrib/losses/jaccard.py
+++ b/keras_contrib/losses/jaccard.py
@@ -37,7 +37,8 @@ def jaccard_distance(y_true, y_pred, smooth=100):
            http://www.bmva.org/bmvc/2013/Papers/paper0032/paper0032.pdf)
 
     """
-    intersection = K.sum(K.abs(y_true * y_pred), axis=-1)
-    sum_ = K.sum(K.abs(y_true) + K.abs(y_pred), axis=-1)
+    shape_dims = list(range(len(y_true.get_shape().as_list())-1))
+    intersection = K.sum(K.abs(y_true * y_pred), axis=shape_dims)
+    sum_ = K.sum(K.abs(y_true) + K.abs(y_pred), axis=shape_dims)
     jac = (intersection + smooth) / (sum_ - intersection + smooth)
     return (1 - jac) * smooth


### PR DESCRIPTION
#526<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras-contrib/blob/master/CONTRIBUTING.md
-->

**- What I did**

Fixed the issue referenced, which concerns implementation of Jaccard Loss function.

**- How I did it**

I changed the **axis** argument of summation terms from *only channels* to *all except channels*, which is the correct way according to what I have studied. Consequently, this returns a **per-channel** loss vector for each sample.

**- How you can verify it**
<!-- 
You need a good justification for not including tests if your pull request is 
a bug fix or adds a new feature to Keras-contrib. 
-->
The functionality and correctness demands (other than theoretical reasoning) verification by training via this loss function. I have used this as well as dice loss (also arranged in a similar configuration) for multiple training sessions which yield good performance.


---
This pull request fixes Issue #526 opened by me
