### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/keras_contrib/applications/nasnet.py
+++ b/keras_contrib/applications/nasnet.py
@@ -590,7 +590,7 @@ def _separable_conv_block(ip, filters, kernel_size=(3, 3), strides=(1, 1),
                           weight_decay=5e-5, id=None):
     '''Adds 2 blocks of [relu-separable conv-batchnorm]
 
-    # Arguments:
+    # Args:
         ip: input tensor
         filters: number of output filters per layer
         kernel_size: kernel size of separable convolutions
@@ -629,7 +629,7 @@ def _adjust_block(p, ip, filters, weight_decay=5e-5, id=None):
     or situations where the output number of filters needs to
     be changed
 
-    # Arguments:
+    # Args:
         p: input tensor which needs to be modified
         ip: input tensor whose shape needs to be matched
         filters: number of output filters to be matched
@@ -687,7 +687,7 @@ def _adjust_block(p, ip, filters, weight_decay=5e-5, id=None):
 def _normal_A(ip, p, filters, weight_decay=5e-5, id=None):
     '''Adds a Normal cell for NASNet-A (Fig. 4 in the paper)
 
-    # Arguments:
+    # Args:
         ip: input tensor `x`
         p: input tensor `p`
         filters: number of output filters
@@ -750,7 +750,7 @@ def _normal_A(ip, p, filters, weight_decay=5e-5, id=None):
 def _reduction_A(ip, p, filters, weight_decay=5e-5, id=None):
     '''Adds a Reduction cell for NASNet-A (Fig. 4 in the paper)
 
-    # Arguments:
+    # Args:
         ip: input tensor `x`
         p: input tensor `p`
         filters: number of output filters

--- a/keras_contrib/callbacks/snapshot.py
+++ b/keras_contrib/callbacks/snapshot.py
@@ -22,7 +22,7 @@ class SnapshotModelCheckpoint(Callback):
     Should be used with the cosine annealing learning rate schedule to save
     the weight just before learning rate is sharply increased.
 
-    # Arguments:
+    # Args:
         nb_epochs: total number of epochs that the model will be trained for.
         nb_snapshots: number of times the weights of the model will be saved.
         fn_prefix: prefix for the filename of the weights.
@@ -55,7 +55,7 @@ class SnapshotCallbackBuilder:
         """
         Initialize a snapshot callback builder.
 
-        # Arguments:
+        # Args:
             nb_epochs: total number of epochs that the model will be trained for.
             nb_snapshots: number of times the weights of the model will be saved.
             init_lr: initial learning rate


### PR DESCRIPTION
**EDIT: I understand your format is some custom one, not the Google one. So not sure, maybe this should be closed, or maybe everything should be conformed to `Args`?**

I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420