### PR TITLE
Adding Keras-Contrib functions using string alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,27 @@ model.fit(x=np.random.random((100, 10)), y=np.random.random((100, 100)), epochs=
 # Save our model
 model.save('example.h5')
 ```
+Modules from Keras-Contrib library in subclass method
 
+```python
+from tensorflow import keras
+from tensorflow.keras import layers
+from keras_contrib.layers.advanced_activations.sinerelu import SineReLU
+from tensorflow.keras.layers import Conv2D, Dense, Flatten, MaxPool2D, Input, Dropout
+from keras.utils.generic_utils import get_custom_objects
+from tensorflow.keras import Model
+from keras.layers import Activation
+
+#calling custom activation functions and adding them to arguments list
+get_custom_objects().update({'SineReLU': Activation(SineReLU)})
+
+class ExampleNet(tf.keras.Model):
+  def __init__(self):
+    super(ExampleNet, self).__init__()
+    self.conv1 = Conv2D(98, (3,3), activation='SineReLU', strides=(4,4))
+    self.norm1 = BatchNormalization()
+```
+    
 
 ### A Common "Gotcha"
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ from tensorflow.keras import layers
 from keras_contrib.layers.advanced_activations.sinerelu import SineReLU
 from tensorflow.keras.layers import Conv2D
 from keras.utils.generic_utils import get_custom_objects
-from tensorflow.keras import Model
 from keras.layers import Activation
 
 #calling custom activation functions and adding them to arguments list

--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ model.fit(x=np.random.random((100, 10)), y=np.random.random((100, 100)), epochs=
 # Save our model
 model.save('example.h5')
 ```
-Modules from Keras-Contrib library in subclass method
+
+### Adding keras-contrib library functions using string alias
 
 ```python
 from tensorflow import keras
 from tensorflow.keras import layers
 from keras_contrib.layers.advanced_activations.sinerelu import SineReLU
-from tensorflow.keras.layers import Conv2D, Dense, Flatten, MaxPool2D, Input, Dropout
+from tensorflow.keras.layers import Conv2D
 from keras.utils.generic_utils import get_custom_objects
 from tensorflow.keras import Model
 from keras.layers import Activation
@@ -96,11 +97,8 @@ from keras.layers import Activation
 #calling custom activation functions and adding them to arguments list
 get_custom_objects().update({'SineReLU': Activation(SineReLU)})
 
-class ExampleNet(tf.keras.Model):
-  def __init__(self):
-    super(ExampleNet, self).__init__()
-    self.conv1 = Conv2D(98, (3,3), activation='SineReLU', strides=(4,4))
-    self.norm1 = BatchNormalization()
+model.add(Conv2D(256, (3,3), activation='SineReLU'))
+
 ```
     
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import numpy as np
 
 # I wish Keras had the Parametric Exponential Linear activation..
 # Oh, wait..!
-from keras_contrib.layers.advanced_activations import PELU
+from keras_contrib.layers.advanced_activations.pelu import PELU
 
 # Create the Keras model, including the PELU advanced activation
 model = Sequential()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras-contrib/blob/master/CONTRIBUTING.md
-->

**- What I did**
I have added the method on how to add functions as activations and others from keras-contrib library using string alias

**- How I did it**
I used get_custom_objects() function from keras.utils.generic_utils 

**- How you can verify it**
I added an example snippet code to teach how string alias method can be used to add functions from keras-contrib library in the README.md file. I don't think that requires to write a test as it only shows how to add string alias not creating or compiling an entire model.
<!-- 
You need a good justification for not including tests if your pull request is 
a bug fix or adds a new feature to Keras-contrib. 
-->



---
This pull request fixes #issue_number_here
